### PR TITLE
feat: new rule prefer-empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ To enable this configuration use the `extends` property in your
 Name | ✔️ | 🛠 | Description
 ----- | ----- | ----- | -----
 [prefer-checked](https://github.com/testing-library/eslint-plugin-jest-dom/blob/master/docs/rules/prefer-checked.md) | ✔️ | 🛠 | prefer toBeChecked over checking attributes
+[prefer-empty](https://github.com/testing-library/eslint-plugin-jest-dom/blob/master/docs/rules/prefer-empty.md) | ✔️ | 🛠 | Prefer toBeEmpty over checking innerHTML
 [prefer-enabled-disabled](https://github.com/testing-library/eslint-plugin-jest-dom/blob/master/docs/rules/prefer-enabled-disabled.md) | ✔️ | 🛠 | prefer toBeDisabled or toBeEnabled over checking attributes
 [prefer-focus](https://github.com/testing-library/eslint-plugin-jest-dom/blob/master/docs/rules/prefer-focus.md) | ✔️ | 🛠 | prefer toHaveFocus over checking document.activeElement
 [prefer-required](https://github.com/testing-library/eslint-plugin-jest-dom/blob/master/docs/rules/prefer-required.md) | ✔️ | 🛠 | prefer toBeRequired over checking properties

--- a/docs/rules/prefer-empty.md
+++ b/docs/rules/prefer-empty.md
@@ -18,25 +18,34 @@ Examples of **incorrect** code for this rule:
     expect(getByText("foo").innerHTML).not.toBe('foo');
     expect(getByText("foo").firstChild).toBe('foo');
     expect(getByText("foo").firstChild).not.toBe('foo');
+    expect(element.innerHTML === '').toBe(true);
+    expect(element.innerHTML !== '').toBe(true);
+    expect(element.innerHTML === '').toBe(false);
+    expect(element.innerHTML !== '').toBe(false);
+    expect(element.firstChild === null).toBe(true);
+    expect(element.firstChild !== null).toBe(false);
+    expect(element.firstChild === null).toBe(false);
 
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-expect(element.innerHTML).toBe('')
-expect(element.innerHTML).toBe(null)
-expect(element.innerHTML).not.toBe(null)
-expect(element.innerHTML).not.toBe('')
-expect(element.firstChild).toBeNull()
-expect(element.firstChild).toBe(null)
-expect(element.firstChild).not.toBe(null)
-expect(element.firstChild).not.toBeNull()
-expect(getByText('foo').innerHTML).toBe('')
-expect(getByText('foo').innerHTML).toStrictEqual('')
-expect(getByText('foo').innerHTML).toStrictEqual(null)
-expect(getByText('foo').firstChild).toBe(null)
-expect(getByText('foo').firstChild).not.toBe(null)
+    expect(element.innerHTML).toBe('');
+    expect(element.innerHTML).toBe(null);
+    expect(element.innerHTML).not.toBe(null);
+    expect(element.innerHTML).not.toBe('');
+    expect(element.firstChild).toBeNull();
+    expect(element.firstChild).toBe(null);
+    expect(element.firstChild).not.toBe(null);
+    expect(element.firstChild).not.toBeNull();
+    expect(getByText('foo').innerHTML).toBe('');
+    expect(getByText('foo').innerHTML).toStrictEqual('');
+    expect(getByText('foo').innerHTML).toStrictEqual(null);
+    expect(getByText('foo').firstChild).toBe(null);
+    expect(getByText('foo').firstChild).not.toBe(null);
+    expect(element.innerHTML === 'foo').toBe(true);
+
 
 ```
 

--- a/docs/rules/prefer-empty.md
+++ b/docs/rules/prefer-empty.md
@@ -1,0 +1,51 @@
+# Prefer toBeEmpty over checking innerHTML / firstChild (prefer-empty)
+
+This rule ensures people will use toBeEmpty() rather than checking dom nodes/properties.  It is primarily aimed at consistently using jest-dom for readability.
+
+## Rule Details
+
+This autofixable rule aims to ensure usage of `.toBeEmpty()`
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+    expect(element.innerHTML).toBe('foo');
+    expect(element.innerHTML).not.toBe('foo');
+    expect(element.firstChild).toBe('foo');
+    expect(element.firstChild).not.toBe('foo');
+    expect(getByText("foo").innerHTML).toBe('foo');
+    expect(getByText("foo").innerHTML).not.toBe('foo');
+    expect(getByText("foo").firstChild).toBe('foo');
+    expect(getByText("foo").firstChild).not.toBe('foo');
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+expect(element.innerHTML).toBe('')
+expect(element.innerHTML).toBe(null)
+expect(element.innerHTML).not.toBe(null)
+expect(element.innerHTML).not.toBe('')
+expect(element.firstChild).toBeNull()
+expect(element.firstChild).toBe(null)
+expect(element.firstChild).not.toBe(null)
+expect(element.firstChild).not.toBeNull()
+expect(getByText('foo').innerHTML).toBe('')
+expect(getByText('foo').innerHTML).toStrictEqual('')
+expect(getByText('foo').innerHTML).toStrictEqual(null)
+expect(getByText('foo').firstChild).toBe(null)
+expect(getByText('foo').firstChild).not.toBe(null)
+
+```
+
+## When Not To Use It
+
+Don't use this rule if you don't care if people use `.toBeEmpty()`.
+
+## Further Reading
+
+<https://github.com/testing-library/jest-dom#tobeempty>
+
+<https://github.com/testing-library/jest-dom/blob/master/src/to-be-empty.js>

--- a/lib/rules/prefer-empty.js
+++ b/lib/rules/prefer-empty.js
@@ -1,0 +1,127 @@
+/**
+ * @fileoverview Prefer toBeEmpty over checking innerHTML
+ * @author Ben Monro
+ */
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Prefer toBeEmpty over checking innerHTML',
+      category: 'jest-dom',
+      recommended: true,
+    },
+    fixable: 'code', // or "code" or "whitespace"
+  },
+
+  create: function(context) {
+    return {
+      [`MemberExpression[property.name = 'innerHTML'][parent.callee.name = 'expect'][parent.parent.property.name = /toBe$|to(Strict)?Equal/]`](
+        node
+      ) {
+        if (!node.parent.parent.parent.arguments[0].value) {
+          context.report({
+            node,
+            message: 'Use toBeEmpty instead of checking inner html.',
+            fix(fixer) {
+              return [
+                fixer.removeRange([node.property.start - 1, node.property.end]),
+                fixer.replaceText(node.parent.parent.property, 'toBeEmpty'),
+                fixer.remove(node.parent.parent.parent.arguments[0]),
+              ];
+            },
+          });
+        }
+      },
+      [`MemberExpression[property.name='innerHTML'][parent.parent.property.name='not'][parent.parent.parent.property.name=/toBe$|to(Strict)?Equal$/][parent.parent.object.callee.name='expect']`](
+        node
+      ) {
+        if (!node.parent.parent.parent.parent.arguments[0].value) {
+          context.report({
+            node,
+            message: 'Use toBeEmpty instead of checking inner html.',
+            fix(fixer) {
+              return [
+                fixer.removeRange([node.property.start - 1, node.property.end]),
+                fixer.replaceText(
+                  node.parent.parent.parent.property,
+                  'toBeEmpty'
+                ),
+                fixer.remove(node.parent.parent.parent.parent.arguments[0]),
+              ];
+            },
+          });
+        }
+      },
+      [`MemberExpression[property.name = 'firstChild'][parent.callee.name = 'expect'][parent.parent.property.name = /toBeNull$/]`](
+        node
+      ) {
+        context.report({
+          node,
+          message: 'Use toBeEmpty instead of checking inner html.',
+          fix(fixer) {
+            return [
+              fixer.removeRange([node.property.start - 1, node.property.end]),
+              fixer.replaceText(node.parent.parent.property, 'toBeEmpty'),
+            ];
+          },
+        });
+      },
+
+      [`MemberExpression[property.name='firstChild'][parent.parent.property.name='not'][parent.parent.parent.property.name=/toBe$|to(Strict)?Equal$/][parent.parent.object.callee.name='expect']`](
+        node
+      ) {
+        if (node.parent.parent.parent.parent.arguments[0].value === null) {
+          context.report({
+            node,
+            message: 'Use toBeEmpty instead of checking inner html.',
+            fix(fixer) {
+              return [
+                fixer.removeRange([node.property.start - 1, node.property.end]),
+                fixer.replaceText(
+                  node.parent.parent.parent.property,
+                  'toBeEmpty'
+                ),
+                fixer.remove(node.parent.parent.parent.parent.arguments[0]),
+              ];
+            },
+          });
+        }
+      },
+
+      [`MemberExpression[property.name='firstChild'][parent.parent.property.name='not'][parent.parent.parent.property.name=/toBeNull$/][parent.parent.object.callee.name='expect']`](
+        node
+      ) {
+        context.report({
+          node,
+          message: 'Use toBeEmpty instead of checking inner html.',
+          fix(fixer) {
+            return [
+              fixer.removeRange([node.property.start - 1, node.property.end]),
+              fixer.replaceText(
+                node.parent.parent.parent.property,
+                'toBeEmpty'
+              ),
+            ];
+          },
+        });
+      },
+      [`MemberExpression[property.name = 'firstChild'][parent.callee.name = 'expect'][parent.parent.property.name = /toBe$|to(Strict)?Equal/]`](
+        node
+      ) {
+        if (node.parent.parent.parent.arguments[0].value === null) {
+          context.report({
+            node,
+            message: 'Use toBeEmpty instead of checking inner html.',
+            fix(fixer) {
+              return [
+                fixer.removeRange([node.property.start - 1, node.property.end]),
+                fixer.replaceText(node.parent.parent.property, 'toBeEmpty'),
+                fixer.remove(node.parent.parent.parent.arguments[0]),
+              ];
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/prefer-empty.js
+++ b/lib/rules/prefer-empty.js
@@ -9,6 +9,7 @@ module.exports = {
       description: 'Prefer toBeEmpty over checking innerHTML',
       category: 'jest-dom',
       recommended: true,
+      url: 'prefer-empty',
     },
     fixable: 'code', // or "code" or "whitespace"
   },

--- a/lib/rules/prefer-empty.js
+++ b/lib/rules/prefer-empty.js
@@ -15,6 +15,48 @@ module.exports = {
 
   create: function(context) {
     return {
+      [`BinaryExpression[left.property.name='innerHTML'][right.value=''][parent.callee.name='expect'][parent.parent.property.name=/toBe$|to(Strict)?Equal/]`](
+        node
+      ) {
+        context.report({
+          node,
+          message: 'Use toBeEmpty instead of checking inner html.',
+          fix(fixer) {
+            return [
+              fixer.removeRange([node.left.property.start - 1, node.end]),
+              fixer.replaceText(
+                node.parent.parent.property,
+                !!node.parent.parent.parent.arguments[0].value ===
+                  node.operator.startsWith('=') // binary expression XNOR matcher boolean
+                  ? 'toBeEmpty'
+                  : 'not.toBeEmpty'
+              ),
+              fixer.remove(node.parent.parent.parent.arguments[0]),
+            ];
+          },
+        });
+      },
+      [`BinaryExpression[left.property.name='firstChild'][right.value=null][parent.callee.name='expect'][parent.parent.property.name=/toBe$|to(Strict)?Equal/]`](
+        node
+      ) {
+        context.report({
+          node,
+          message: 'Use toBeEmpty instead of checking inner html.',
+          fix(fixer) {
+            return [
+              fixer.removeRange([node.left.property.start - 1, node.end]),
+              fixer.replaceText(
+                node.parent.parent.property,
+                !!node.parent.parent.parent.arguments[0].value ===
+                  node.operator.startsWith('=') // binary expression XNOR matcher boolean
+                  ? 'toBeEmpty'
+                  : 'not.toBeEmpty'
+              ),
+              fixer.remove(node.parent.parent.parent.arguments[0]),
+            ];
+          },
+        });
+      },
       [`MemberExpression[property.name = 'innerHTML'][parent.callee.name = 'expect'][parent.parent.property.name = /toBe$|to(Strict)?Equal/]`](
         node
       ) {

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -21,6 +21,7 @@ Object {
         "category": "jest-dom",
         "description": "Prefer toBeEmpty over checking innerHTML",
         "recommended": true,
+        "url": "prefer-empty",
       },
       "fixable": "code",
     },

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -14,6 +14,17 @@ Object {
       "fixable": "code",
     },
   },
+  "prefer-empty": Object {
+    "create": [Function],
+    "meta": Object {
+      "docs": Object {
+        "category": "jest-dom",
+        "description": "Prefer toBeEmpty over checking innerHTML",
+        "recommended": true,
+      },
+      "fixable": "code",
+    },
+  },
   "prefer-enabled-disabled": Object {
     "create": [Function],
     "meta": Object {

--- a/tests/lib/rules/prefer-empty.js
+++ b/tests/lib/rules/prefer-empty.js
@@ -26,9 +26,74 @@ ruleTester.run('prefer-empty', rule, {
     `expect(getByText("foo").innerHTML).not.toBe('foo')`,
     `expect(getByText("foo").firstChild).toBe('foo')`,
     `expect(getByText("foo").firstChild).not.toBe('foo')`,
+    `expect(element.innerHTML === 'foo').toBe(true)`,
+    `expect(element.innerHTML !== 'foo').toBe(true)`,
   ],
 
   invalid: [
+    {
+      code: `expect(element.innerHTML === '').toBe(true)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).toBeEmpty()`,
+    },
+    {
+      code: `expect(element.innerHTML !== '').toBe(true)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).not.toBeEmpty()`,
+    },
+    {
+      code: `expect(element.innerHTML === '').toBe(false)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).not.toBeEmpty()`,
+    },
+    {
+      code: `expect(element.innerHTML !== '').toBe(false)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).toBeEmpty()`,
+    },
+    {
+      code: `expect(element.firstChild === null).toBe(true)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).toBeEmpty()`,
+    },
+    {
+      code: `expect(element.firstChild !== null).toBe(false)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).toBeEmpty()`,
+    },
+    {
+      code: `expect(element.firstChild === null).toBe(false)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).not.toBeEmpty()`,
+    },
     {
       code: `expect(element.innerHTML).toBe('')`,
       errors: [
@@ -38,6 +103,7 @@ ruleTester.run('prefer-empty', rule, {
       ],
       output: `expect(element).toBeEmpty()`,
     },
+
     {
       code: `expect(element.innerHTML).toBe(null)`,
       errors: [

--- a/tests/lib/rules/prefer-empty.js
+++ b/tests/lib/rules/prefer-empty.js
@@ -1,0 +1,156 @@
+/**
+ * @fileoverview Prefer toBeEmpty over checking innerHTML
+ * @author Ben Monro
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+let rule = require('../../../lib/rules/prefer-empty'),
+  RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+let ruleTester = new RuleTester();
+ruleTester.run('prefer-empty', rule, {
+  valid: [
+    `expect(element.innerHTML).toBe('foo')`,
+    `expect(element.innerHTML).not.toBe('foo')`,
+    `expect(element.firstChild).toBe('foo')`,
+    `expect(element.firstChild).not.toBe('foo')`,
+    `expect(getByText("foo").innerHTML).toBe('foo')`,
+    `expect(getByText("foo").innerHTML).not.toBe('foo')`,
+    `expect(getByText("foo").firstChild).toBe('foo')`,
+    `expect(getByText("foo").firstChild).not.toBe('foo')`,
+  ],
+
+  invalid: [
+    {
+      code: `expect(element.innerHTML).toBe('')`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).toBeEmpty()`,
+    },
+    {
+      code: `expect(element.innerHTML).toBe(null)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).toBeEmpty()`,
+    },
+    {
+      code: `expect(element.innerHTML).not.toBe(null)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).not.toBeEmpty()`,
+    },
+
+    {
+      code: `expect(element.innerHTML).not.toBe('')`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).not.toBeEmpty()`,
+    },
+
+    {
+      code: `expect(element.firstChild).toBeNull()`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).toBeEmpty()`,
+    },
+    {
+      code: `expect(element.firstChild).toBe(null)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).toBeEmpty()`,
+    },
+    {
+      code: `expect(element.firstChild).not.toBe(null)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).not.toBeEmpty()`,
+    },
+
+    {
+      code: `expect(element.firstChild).not.toBeNull()`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(element).not.toBeEmpty()`,
+    },
+    {
+      code: `expect(getByText('foo').innerHTML).toBe('')`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(getByText('foo')).toBeEmpty()`,
+    },
+
+    {
+      code: `expect(getByText('foo').innerHTML).toStrictEqual('')`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(getByText('foo')).toBeEmpty()`,
+    },
+
+    {
+      code: `expect(getByText('foo').innerHTML).toStrictEqual(null)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(getByText('foo')).toBeEmpty()`,
+    },
+
+    {
+      code: `expect(getByText('foo').firstChild).toBe(null)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(getByText('foo')).toBeEmpty()`,
+    },
+    {
+      code: `expect(getByText('foo').firstChild).not.toBe(null)`,
+      errors: [
+        {
+          message: 'Use toBeEmpty instead of checking inner html.',
+        },
+      ],
+      output: `expect(getByText('foo')).not.toBeEmpty()`,
+    },
+  ],
+});


### PR DESCRIPTION
see docs in this PR for details.  

new autofixable rule for `.toBeEmpty()` use cases.

fixes #7 