### PR TITLE
fix: use range instead of start/end properties

### DIFF
--- a/lib/createBannedAttributeRule.js
+++ b/lib/createBannedAttributeRule.js
@@ -25,7 +25,7 @@ module.exports = ({ preferred, negatedPreferred, attributes }) => context => {
           node,
           fix(fixer) {
             return fixer.replaceTextRange(
-              [node.callee.object.property.start, node.end],
+              [node.callee.object.property.range[0], node.range[1]],
               `${correctFunction}()`
             );
           },
@@ -55,9 +55,9 @@ module.exports = ({ preferred, negatedPreferred, attributes }) => context => {
           message: `Use ${correctFunction}() instead of checking .${name} directly`,
           fix(fixer) {
             return [
-              fixer.removeRange([property.start - 1, property.end]),
+              fixer.removeRange([property.range[0] - 1, property.range[1]]),
               fixer.replaceTextRange(
-                [node.callee.property.start, node.end],
+                [node.callee.property.range[0], node.range[1]],
                 `${correctFunction}()`
               ),
             ];
@@ -78,7 +78,7 @@ module.exports = ({ preferred, negatedPreferred, attributes }) => context => {
           node,
           fix(fixer) {
             return fixer.replaceTextRange(
-              [node.callee.object.property.start, node.end],
+              [node.callee.object.property.range[0], node.range[1]],
               `${correctFunction}()`
             );
           },
@@ -102,7 +102,7 @@ module.exports = ({ preferred, negatedPreferred, attributes }) => context => {
           fix(fixer) {
             return [
               fixer.replaceTextRange(
-                [node.callee.property.start, node.end],
+                [node.callee.property.range[0], node.range[1]],
                 `${correctFunction}()`
               ),
             ];

--- a/lib/rules/prefer-empty.js
+++ b/lib/rules/prefer-empty.js
@@ -24,7 +24,10 @@ module.exports = {
           message: 'Use toBeEmpty instead of checking inner html.',
           fix(fixer) {
             return [
-              fixer.removeRange([node.left.property.range[0] - 1, node.range[1]]),
+              fixer.removeRange([
+                node.left.property.range[0] - 1,
+                node.range[1],
+              ]),
               fixer.replaceText(
                 node.parent.parent.property,
                 !!node.parent.parent.parent.arguments[0].value ===
@@ -45,7 +48,10 @@ module.exports = {
           message: 'Use toBeEmpty instead of checking inner html.',
           fix(fixer) {
             return [
-              fixer.removeRange([node.left.property.range[0] - 1, node.range[1]]),
+              fixer.removeRange([
+                node.left.property.range[0] - 1,
+                node.range[1],
+              ]),
               fixer.replaceText(
                 node.parent.parent.property,
                 !!node.parent.parent.parent.arguments[0].value ===
@@ -67,7 +73,10 @@ module.exports = {
             message: 'Use toBeEmpty instead of checking inner html.',
             fix(fixer) {
               return [
-                fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
+                fixer.removeRange([
+                  node.property.range[0] - 1,
+                  node.property.range[1],
+                ]),
                 fixer.replaceText(node.parent.parent.property, 'toBeEmpty'),
                 fixer.remove(node.parent.parent.parent.arguments[0]),
               ];
@@ -84,7 +93,10 @@ module.exports = {
             message: 'Use toBeEmpty instead of checking inner html.',
             fix(fixer) {
               return [
-                fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
+                fixer.removeRange([
+                  node.property.range[0] - 1,
+                  node.property.range[1],
+                ]),
                 fixer.replaceText(
                   node.parent.parent.parent.property,
                   'toBeEmpty'
@@ -103,7 +115,10 @@ module.exports = {
           message: 'Use toBeEmpty instead of checking inner html.',
           fix(fixer) {
             return [
-              fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
+              fixer.removeRange([
+                node.property.range[0] - 1,
+                node.property.range[1],
+              ]),
               fixer.replaceText(node.parent.parent.property, 'toBeEmpty'),
             ];
           },
@@ -119,7 +134,10 @@ module.exports = {
             message: 'Use toBeEmpty instead of checking inner html.',
             fix(fixer) {
               return [
-                fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
+                fixer.removeRange([
+                  node.property.range[0] - 1,
+                  node.property.range[1],
+                ]),
                 fixer.replaceText(
                   node.parent.parent.parent.property,
                   'toBeEmpty'
@@ -139,7 +157,10 @@ module.exports = {
           message: 'Use toBeEmpty instead of checking inner html.',
           fix(fixer) {
             return [
-              fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
+              fixer.removeRange([
+                node.property.range[0] - 1,
+                node.property.range[1],
+              ]),
               fixer.replaceText(
                 node.parent.parent.parent.property,
                 'toBeEmpty'
@@ -157,7 +178,10 @@ module.exports = {
             message: 'Use toBeEmpty instead of checking inner html.',
             fix(fixer) {
               return [
-                fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
+                fixer.removeRange([
+                  node.property.range[0] - 1,
+                  node.property.range[1],
+                ]),
                 fixer.replaceText(node.parent.parent.property, 'toBeEmpty'),
                 fixer.remove(node.parent.parent.parent.arguments[0]),
               ];

--- a/lib/rules/prefer-empty.js
+++ b/lib/rules/prefer-empty.js
@@ -24,7 +24,7 @@ module.exports = {
           message: 'Use toBeEmpty instead of checking inner html.',
           fix(fixer) {
             return [
-              fixer.removeRange([node.left.property.start - 1, node.end]),
+              fixer.removeRange([node.left.property.range[0] - 1, node.range[1]]),
               fixer.replaceText(
                 node.parent.parent.property,
                 !!node.parent.parent.parent.arguments[0].value ===
@@ -45,7 +45,7 @@ module.exports = {
           message: 'Use toBeEmpty instead of checking inner html.',
           fix(fixer) {
             return [
-              fixer.removeRange([node.left.property.start - 1, node.end]),
+              fixer.removeRange([node.left.property.range[0] - 1, node.range[1]]),
               fixer.replaceText(
                 node.parent.parent.property,
                 !!node.parent.parent.parent.arguments[0].value ===
@@ -67,7 +67,7 @@ module.exports = {
             message: 'Use toBeEmpty instead of checking inner html.',
             fix(fixer) {
               return [
-                fixer.removeRange([node.property.start - 1, node.property.end]),
+                fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
                 fixer.replaceText(node.parent.parent.property, 'toBeEmpty'),
                 fixer.remove(node.parent.parent.parent.arguments[0]),
               ];
@@ -84,7 +84,7 @@ module.exports = {
             message: 'Use toBeEmpty instead of checking inner html.',
             fix(fixer) {
               return [
-                fixer.removeRange([node.property.start - 1, node.property.end]),
+                fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
                 fixer.replaceText(
                   node.parent.parent.parent.property,
                   'toBeEmpty'
@@ -103,7 +103,7 @@ module.exports = {
           message: 'Use toBeEmpty instead of checking inner html.',
           fix(fixer) {
             return [
-              fixer.removeRange([node.property.start - 1, node.property.end]),
+              fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
               fixer.replaceText(node.parent.parent.property, 'toBeEmpty'),
             ];
           },
@@ -119,7 +119,7 @@ module.exports = {
             message: 'Use toBeEmpty instead of checking inner html.',
             fix(fixer) {
               return [
-                fixer.removeRange([node.property.start - 1, node.property.end]),
+                fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
                 fixer.replaceText(
                   node.parent.parent.parent.property,
                   'toBeEmpty'
@@ -139,7 +139,7 @@ module.exports = {
           message: 'Use toBeEmpty instead of checking inner html.',
           fix(fixer) {
             return [
-              fixer.removeRange([node.property.start - 1, node.property.end]),
+              fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
               fixer.replaceText(
                 node.parent.parent.parent.property,
                 'toBeEmpty'
@@ -157,7 +157,7 @@ module.exports = {
             message: 'Use toBeEmpty instead of checking inner html.',
             fix(fixer) {
               return [
-                fixer.removeRange([node.property.start - 1, node.property.end]),
+                fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
                 fixer.replaceText(node.parent.parent.property, 'toBeEmpty'),
                 fixer.remove(node.parent.parent.parent.arguments[0]),
               ];

--- a/lib/rules/prefer-focus.js
+++ b/lib/rules/prefer-focus.js
@@ -47,9 +47,9 @@ module.exports = {
               ];
             } else {
               return [
-                fixer.removeRange([node.start, element.start]),
+                fixer.removeRange([node.range[0], element.range[0]]),
                 fixer.insertTextAfterRange(
-                  [element.end, element.end + 1],
+                  [element.range[1], element.range[1] + 1],
                   '.not.toHaveFocus()'
                 ),
               ];
@@ -89,9 +89,9 @@ module.exports = {
           fix(fixer) {
             if (!element.name) {
               return [
-                fixer.removeRange([node.start, element.start]),
+                fixer.removeRange([node.range[0], element.range[0]]),
                 fixer.insertTextAfterRange(
-                  [element.end, element.end + 1],
+                  [element.range[1], element.range[1] + 1],
                   '.toHaveFocus()'
                 ),
               ];

--- a/lib/rules/prefer-to-have-attribute.js
+++ b/lib/rules/prefer-to-have-attribute.js
@@ -28,11 +28,11 @@ module.exports = {
           message: `Use toHaveAttribute instead of asserting on getAttribute`,
           fix(fixer) {
             return [
-              fixer.removeRange([node.callee.object.end, node.end]),
+              fixer.removeRange([node.callee.object.range[1], node.range[1]]),
               fixer.replaceTextRange(
                 [
-                  node.parent.parent.property.start,
-                  node.parent.parent.parent.end,
+                  node.parent.parent.property.range[0],
+                  node.parent.parent.parent.range[1],
                 ],
                 `not.toHaveAttribute(${node.arguments[0].raw})`
               ),
@@ -48,7 +48,7 @@ module.exports = {
           message: `Use toHaveAttribute instead of asserting on getAttribute`,
           fix(fixer) {
             return [
-              fixer.removeRange([node.callee.object.end, node.end]),
+              fixer.removeRange([node.callee.object.range[1], node.range[1]]),
               fixer.replaceText(node.parent.parent.property, 'toHaveAttribute'),
               fixer.replaceText(
                 node.parent.parent.parent.arguments[0],
@@ -86,7 +86,7 @@ module.exports = {
               );
             }
             return [
-              fixer.removeRange([node.callee.object.end, node.end]),
+              fixer.removeRange([node.callee.object.range[1], node.range[1]]),
               fixer.replaceText(
                 node.parent.parent.property,
                 `${isNullOrEmpty ? 'not.' : ''}toHaveAttribute`
@@ -121,7 +121,7 @@ module.exports = {
             message: `Use toHaveAttribute instead of asserting on hasAttribute`,
             fix(fixer) {
               return [
-                fixer.removeRange([node.callee.object.end, node.end]),
+                fixer.removeRange([node.callee.object.range[1], node.range[1]]),
                 fixer.replaceText(
                   node.parent.parent.property,
                   `${
@@ -152,11 +152,11 @@ module.exports = {
           message: `Use toHaveAttribute instead of asserting on hasAttribute`,
           fix(fixer) {
             return [
-              fixer.removeRange([node.callee.object.end, node.end]),
+              fixer.removeRange([node.callee.object.range[1], node.range[1]]),
               fixer.replaceTextRange(
                 [
-                  node.parent.parent.property.start,
-                  node.parent.parent.parent.end,
+                  node.parent.parent.property.range[0],
+                  node.parent.parent.parent.range[1],
                 ],
                 `${
                   node.parent.parent.property.name === 'toBeFalsy' ? 'not.' : ''


### PR DESCRIPTION
This PR replaces usage of non standard fields start, end with range. (based on https://github.com/jest-community/eslint-plugin-jest/pull/221)

Properties start, end should not be used (they may be removed in feature)

currently those rules are crashing because of that if you decide to use (@typescript-eslint/parser)

see: https://eslint.org/docs/developer-guide/working-with-custom-parsers#all-nodes

fixes: #27 