### PR TITLE
feat: migrate toBeEmpty to toBeEmptyDOMElement

### DIFF
--- a/docs/rules/prefer-empty.md
+++ b/docs/rules/prefer-empty.md
@@ -1,12 +1,12 @@
-# Prefer toBeEmpty over checking innerHTML / firstChild (prefer-empty)
+# Prefer toBeEmptyDOMElement over checking innerHTML / firstChild (prefer-empty)
 
-This rule ensures people will use toBeEmpty() rather than checking dom
+This rule ensures people will use toBeEmptyDOMElement() rather than checking dom
 nodes/properties. It is primarily aimed at consistently using jest-dom for
 readability.
 
 ## Rule Details
 
-This autofixable rule aims to ensure usage of `.toBeEmpty()`
+This autofixable rule aims to ensure usage of `.toBeEmptyDOMElement()`
 
 Examples of **incorrect** code for this rule:
 
@@ -49,10 +49,14 @@ expect(element.innerHTML === "foo").toBe(true);
 
 ## When Not To Use It
 
-Don't use this rule if you don't care if people use `.toBeEmpty()`.
+Don't use this rule if you don't care if people use `.toBeEmptyDOMElement()`.
 
 ## Further Reading
 
-<https://github.com/testing-library/jest-dom#tobeempty>
+<https://github.com/testing-library/jest-dom#tobeemptydomelement>
 
-<https://github.com/testing-library/jest-dom/blob/master/src/to-be-empty.js>
+<https://github.com/testing-library/jest-dom/blob/master/src/to-be-empty-dom-element.js>
+
+## Changelog
+
+Previously, this rule was using `.toBeEmpty` which has been [deprecated](https://github.com/testing-library/jest-dom/releases/tag/v5.9.0) in `@testing-library/jest-dom@5.9.0`.

--- a/src/__tests__/lib/rules/prefer-empty.js
+++ b/src/__tests__/lib/rules/prefer-empty.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Prefer toBeEmpty over checking innerHTML
+ * @fileoverview Prefer toBeEmptyDOMElement over checking innerHTML
  * @author Ben Monro
  */
 
@@ -34,188 +34,188 @@ ruleTester.run("prefer-empty", rule, {
       code: `expect(element.innerHTML === '').toBe(true)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).toBeEmpty()`,
+      output: `expect(element).toBeEmptyDOMElement()`,
     },
     {
       code: `expect(element.innerHTML !== '').toBe(true)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).not.toBeEmpty()`,
+      output: `expect(element).not.toBeEmptyDOMElement()`,
     },
     {
       code: `expect(element.innerHTML === '').toBe(false)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).not.toBeEmpty()`,
+      output: `expect(element).not.toBeEmptyDOMElement()`,
     },
     {
       code: `expect(element.innerHTML !== '').toBe(false)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).toBeEmpty()`,
+      output: `expect(element).toBeEmptyDOMElement()`,
     },
     {
       code: `expect(element.firstChild === null).toBe(true)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).toBeEmpty()`,
+      output: `expect(element).toBeEmptyDOMElement()`,
     },
     {
       code: `expect(element.firstChild !== null).toBe(false)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).toBeEmpty()`,
+      output: `expect(element).toBeEmptyDOMElement()`,
     },
     {
       code: `expect(element.firstChild === null).toBe(false)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).not.toBeEmpty()`,
+      output: `expect(element).not.toBeEmptyDOMElement()`,
     },
     {
       code: `expect(element.innerHTML).toBe('')`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).toBeEmpty()`,
+      output: `expect(element).toBeEmptyDOMElement()`,
     },
 
     {
       code: `expect(element.innerHTML).toBe(null)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).toBeEmpty()`,
+      output: `expect(element).toBeEmptyDOMElement()`,
     },
     {
       code: `expect(element.innerHTML).not.toBe(null)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).not.toBeEmpty()`,
+      output: `expect(element).not.toBeEmptyDOMElement()`,
     },
 
     {
       code: `expect(element.innerHTML).not.toBe('')`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).not.toBeEmpty()`,
+      output: `expect(element).not.toBeEmptyDOMElement()`,
     },
 
     {
       code: `expect(element.firstChild).toBeNull()`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).toBeEmpty()`,
+      output: `expect(element).toBeEmptyDOMElement()`,
     },
     {
       code: `expect(element.firstChild).toBe(null)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).toBeEmpty()`,
+      output: `expect(element).toBeEmptyDOMElement()`,
     },
     {
       code: `expect(element.firstChild).not.toBe(null)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).not.toBeEmpty()`,
+      output: `expect(element).not.toBeEmptyDOMElement()`,
     },
 
     {
       code: `expect(element.firstChild).not.toBeNull()`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(element).not.toBeEmpty()`,
+      output: `expect(element).not.toBeEmptyDOMElement()`,
     },
     {
       code: `expect(getByText('foo').innerHTML).toBe('')`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(getByText('foo')).toBeEmpty()`,
+      output: `expect(getByText('foo')).toBeEmptyDOMElement()`,
     },
 
     {
       code: `expect(getByText('foo').innerHTML).toStrictEqual('')`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(getByText('foo')).toBeEmpty()`,
+      output: `expect(getByText('foo')).toBeEmptyDOMElement()`,
     },
 
     {
       code: `expect(getByText('foo').innerHTML).toStrictEqual(null)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(getByText('foo')).toBeEmpty()`,
+      output: `expect(getByText('foo')).toBeEmptyDOMElement()`,
     },
 
     {
       code: `expect(getByText('foo').firstChild).toBe(null)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(getByText('foo')).toBeEmpty()`,
+      output: `expect(getByText('foo')).toBeEmptyDOMElement()`,
     },
     {
       code: `expect(getByText('foo').firstChild).not.toBe(null)`,
       errors: [
         {
-          message: "Use toBeEmpty instead of checking inner html.",
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
         },
       ],
-      output: `expect(getByText('foo')).not.toBeEmpty()`,
+      output: `expect(getByText('foo')).not.toBeEmptyDOMElement()`,
     },
   ],
 });

--- a/src/rules/prefer-empty.js
+++ b/src/rules/prefer-empty.js
@@ -19,15 +19,15 @@ export const create = (context) => ({
   ) {
     context.report({
       node,
-      message: "Use toBeEmpty instead of checking inner html.",
+      message: "Use toBeEmptyDOMElement instead of checking inner html.",
       fix: (fixer) => [
         fixer.removeRange([node.left.property.range[0] - 1, node.range[1]]),
         fixer.replaceText(
           node.parent.parent.property,
           Boolean(node.parent.parent.parent.arguments[0].value) ===
             node.operator.startsWith("=") // binary expression XNOR matcher boolean
-            ? "toBeEmpty"
-            : "not.toBeEmpty"
+            ? "toBeEmptyDOMElement"
+            : "not.toBeEmptyDOMElement"
         ),
         fixer.remove(node.parent.parent.parent.arguments[0]),
       ],
@@ -38,15 +38,15 @@ export const create = (context) => ({
   ) {
     context.report({
       node,
-      message: "Use toBeEmpty instead of checking inner html.",
+      message: "Use toBeEmptyDOMElement instead of checking inner html.",
       fix: (fixer) => [
         fixer.removeRange([node.left.property.range[0] - 1, node.range[1]]),
         fixer.replaceText(
           node.parent.parent.property,
           Boolean(node.parent.parent.parent.arguments[0].value) ===
             node.operator.startsWith("=") // binary expression XNOR matcher boolean
-            ? "toBeEmpty"
-            : "not.toBeEmpty"
+            ? "toBeEmptyDOMElement"
+            : "not.toBeEmptyDOMElement"
         ),
         fixer.remove(node.parent.parent.parent.arguments[0]),
       ],
@@ -61,10 +61,10 @@ export const create = (context) => ({
 
     context.report({
       node,
-      message: "Use toBeEmpty instead of checking inner html.",
+      message: "Use toBeEmptyDOMElement instead of checking inner html.",
       fix: (fixer) => [
         fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
-        fixer.replaceText(node.parent.parent.property, "toBeEmpty"),
+        fixer.replaceText(node.parent.parent.property, "toBeEmptyDOMElement"),
         fixer.remove(node.parent.parent.parent.arguments[0]),
       ],
     });
@@ -78,10 +78,13 @@ export const create = (context) => ({
 
     context.report({
       node,
-      message: "Use toBeEmpty instead of checking inner html.",
+      message: "Use toBeEmptyDOMElement instead of checking inner html.",
       fix: (fixer) => [
         fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
-        fixer.replaceText(node.parent.parent.parent.property, "toBeEmpty"),
+        fixer.replaceText(
+          node.parent.parent.parent.property,
+          "toBeEmptyDOMElement"
+        ),
         fixer.remove(node.parent.parent.parent.parent.arguments[0]),
       ],
     });
@@ -91,10 +94,10 @@ export const create = (context) => ({
   ) {
     context.report({
       node,
-      message: "Use toBeEmpty instead of checking inner html.",
+      message: "Use toBeEmptyDOMElement instead of checking inner html.",
       fix: (fixer) => [
         fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
-        fixer.replaceText(node.parent.parent.property, "toBeEmpty"),
+        fixer.replaceText(node.parent.parent.property, "toBeEmptyDOMElement"),
       ],
     });
   },
@@ -107,10 +110,13 @@ export const create = (context) => ({
 
     context.report({
       node,
-      message: "Use toBeEmpty instead of checking inner html.",
+      message: "Use toBeEmptyDOMElement instead of checking inner html.",
       fix: (fixer) => [
         fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
-        fixer.replaceText(node.parent.parent.parent.property, "toBeEmpty"),
+        fixer.replaceText(
+          node.parent.parent.parent.property,
+          "toBeEmptyDOMElement"
+        ),
         fixer.remove(node.parent.parent.parent.parent.arguments[0]),
       ],
     });
@@ -120,10 +126,13 @@ export const create = (context) => ({
   ) {
     context.report({
       node,
-      message: "Use toBeEmpty instead of checking inner html.",
+      message: "Use toBeEmptyDOMElement instead of checking inner html.",
       fix: (fixer) => [
         fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
-        fixer.replaceText(node.parent.parent.parent.property, "toBeEmpty"),
+        fixer.replaceText(
+          node.parent.parent.parent.property,
+          "toBeEmptyDOMElement"
+        ),
       ],
     });
   },
@@ -136,10 +145,10 @@ export const create = (context) => ({
 
     context.report({
       node,
-      message: "Use toBeEmpty instead of checking inner html.",
+      message: "Use toBeEmptyDOMElement instead of checking inner html.",
       fix: (fixer) => [
         fixer.removeRange([node.property.range[0] - 1, node.property.range[1]]),
-        fixer.replaceText(node.parent.parent.property, "toBeEmpty"),
+        fixer.replaceText(node.parent.parent.property, "toBeEmptyDOMElement"),
         fixer.remove(node.parent.parent.parent.arguments[0]),
       ],
     });


### PR DESCRIPTION


**What**:

- migrates `toBeEmpty` to `toBeEmptyDOMElement`
- fixes #55

**Why**:

`.toBeEmpty` was deprecated and `jest-dom` will cry.

**How**:

more or less find/replace `toBeEmpty` with `toBeEmptyDOMElement`

**Checklist**:


- [x] Documentation
- [x] Tests
- [x] Ready to be merged

Anything else missing?