### PR TITLE
fix(prefer-checked): don't auto-fix when 2nd argument is a non literal.

### DIFF
--- a/docs/rules/prefer-checked.md
+++ b/docs/rules/prefer-checked.md
@@ -47,6 +47,7 @@ Examples of **incorrect** code for this rule:
 ```js
 expect(element).toHaveProperty("checked", true);
 expect(element).toHaveAttribute("checked", false);
+expect(element).toHaveProperty("checked", something);
 
 expect(element).toHaveAttribute("checked");
 expect(element).not.toHaveProperty("checked");

--- a/package.json
+++ b/package.json
@@ -43,10 +43,7 @@
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",
     "rules": {
-      "babel/quotes": [
-        "error",
-        "double"
-      ]
+      "babel/quotes": "off"
     }
   },
   "eslintIgnore": [

--- a/package.json
+++ b/package.json
@@ -41,7 +41,13 @@
     "eslint": "^7.0.0"
   },
   "eslintConfig": {
-    "extends": "./node_modules/kcd-scripts/eslint.js"
+    "extends": "./node_modules/kcd-scripts/eslint.js",
+    "rules": {
+      "babel/quotes": [
+        "error",
+        "double"
+      ]
+    }
   },
   "eslintIgnore": [
     "node_modules",

--- a/src/__tests__/__fixtures__/createBannedAttributeTestCases.js
+++ b/src/__tests__/__fixtures__/createBannedAttributeTestCases.js
@@ -57,10 +57,10 @@ export default ({ preferred, negatedPreferred, attribute }) => {
 
   return {
     valid: [
-      `expect(element).not.toHaveProperty('value', 'foo')`,
+      "expect(element).not.toHaveProperty('value', 'foo')",
       `expect(element).${preferred}`,
       `expect(element).${negatedPreferred}`,
-      `expect(element).toHaveProperty('value', 'bar')`,
+      "expect(element).toHaveProperty('value', 'bar')",
     ],
     invalid: [
       ...doubleNegativeCases,
@@ -154,6 +154,14 @@ export default ({ preferred, negatedPreferred, attribute }) => {
           },
         ],
         output: `expect(getByText("foo")).${negatedPreferred}`,
+      },
+      {
+        code: `expect(element).toHaveProperty('${attribute}', foo)`,
+        errors: [
+          {
+            message: `Use ${preferred} instead of toHaveProperty('${attribute}', foo)`,
+          },
+        ],
       },
     ],
   };

--- a/src/createBannedAttributeRule.js
+++ b/src/createBannedAttributeRule.js
@@ -2,6 +2,7 @@ export default ({ preferred, negatedPreferred, attributes }) => (context) => {
   const getCorrectFunctionFor = (node, negated = false) =>
     (node.arguments.length === 1 ||
       node.arguments[1].value === true ||
+      node.arguments[1].type !== "Literal" ||
       node.arguments[1].value === "") &&
     !negated
       ? preferred
@@ -32,7 +33,7 @@ export default ({ preferred, negatedPreferred, attributes }) => (context) => {
           ),
       });
     },
-    [`CallExpression[callee.property.name=/toBe(Truthy|Falsy)?|toEqual/][callee.object.callee.name='expect']`](
+    "CallExpression[callee.property.name=/toBe(Truthy|Falsy)?|toEqual/][callee.object.callee.name='expect']"(
       node
     ) {
       const {
@@ -63,7 +64,7 @@ export default ({ preferred, negatedPreferred, attributes }) => (context) => {
         ],
       });
     },
-    [`CallExpression[callee.property.name=/toHaveProperty|toHaveAttribute/][callee.object.property.name='not'][callee.object.object.callee.name='expect']`](
+    "CallExpression[callee.property.name=/toHaveProperty|toHaveAttribute/][callee.object.property.name='not'][callee.object.object.callee.name='expect']"(
       node
     ) {
       const arg = node.arguments[0].value;
@@ -84,7 +85,7 @@ export default ({ preferred, negatedPreferred, attributes }) => (context) => {
           ),
       });
     },
-    [`CallExpression[callee.object.callee.name='expect'][callee.property.name=/toHaveProperty|toHaveAttribute/]`](
+    "CallExpression[callee.object.callee.name='expect'][callee.property.name=/toHaveProperty|toHaveAttribute/]"(
       node
     ) {
       if (!isBannedArg(node)) {
@@ -96,17 +97,27 @@ export default ({ preferred, negatedPreferred, attributes }) => (context) => {
       const incorrectFunction = node.callee.property.name;
 
       const message = `Use ${correctFunction}() instead of ${incorrectFunction}(${node.arguments
-        .map(({ raw }) => raw)
+        .map(({ raw, name }) => raw || name)
         .join(", ")})`;
+
+      const secondArgIsLiteral =
+        node.arguments.length === 2 && node.arguments[1].type === "Literal";
+
       context.report({
         node: node.callee.property,
         message,
-        fix: (fixer) => [
-          fixer.replaceTextRange(
-            [node.callee.property.range[0], node.range[1]],
-            `${correctFunction}()`
-          ),
-        ],
+        fix: (fixer) => {
+          if (node.arguments.length === 1 || secondArgIsLiteral) {
+            return [
+              fixer.replaceTextRange(
+                [node.callee.property.range[0], node.range[1]],
+                `${correctFunction}()`
+              ),
+            ];
+          }
+
+          return null;
+        },
       });
     },
   };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: fixes banned attribute checks with 2nd arg passed as non literal value.

<!-- Why are these changes necessary? -->

**Why**: fixes https://github.com/testing-library/eslint-plugin-jest-dom/issues/58

<!-- How were these changes implemented? -->

**How**: add check for non literal 2nd arg, return null from fixer if present.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->