### PR TITLE
fix(to-have-text-content): improved handling non literals and regex in autofix

### DIFF
--- a/src/__tests__/lib/rules/prefer-to-have-text-content.js
+++ b/src/__tests__/lib/rules/prefer-to-have-text-content.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-template-curly-in-string */
 /**
  * @fileoverview Prefer toHaveTextContent over checking element.textContent
  * @author Ben Monro
@@ -14,7 +15,7 @@ import * as rule from "../../../rules/prefer-to-have-text-content";
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 ruleTester.run("prefer-to-have-text-content", rule, {
   valid: [
     `expect(string).toBe("foo")`,
@@ -92,6 +93,47 @@ ruleTester.run("prefer-to-have-text-content", rule, {
         },
       ],
       output: `expect(container.firstChild).toHaveTextContent(/foo/)`,
+    },
+    {
+      code: `expect(container.textContent).toContain(FOO.bar)`,
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: `expect(container).toHaveTextContent(new RegExp(FOO.bar))`,
+    },
+    {
+      code: `expect(container.textContent).not.toContain(FOO.bar)`,
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: `expect(container).not.toHaveTextContent(new RegExp(FOO.bar))`,
+    },
+    {
+      code: "expect(container.textContent).toContain(`${FOO.bar} baz`)",
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output:
+        "expect(container).toHaveTextContent(new RegExp(`${FOO.bar} baz`))",
+    },
+    {
+      code: `expect(container.textContent).toContain(bazify(FOO.bar))`,
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: `expect(container).toHaveTextContent(new RegExp(bazify(FOO.bar)))`,
     },
     {
       code: 'expect(element.textContent).toMatch("foo")',

--- a/src/__tests__/lib/rules/prefer-to-have-text-content.js
+++ b/src/__tests__/lib/rules/prefer-to-have-text-content.js
@@ -146,6 +146,27 @@ ruleTester.run("prefer-to-have-text-content", rule, {
       output: `expect(element).toHaveTextContent(/foo/)`,
     },
     {
+      code: "expect(element.textContent).toMatch(/foo bar/)",
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: "expect(element).toHaveTextContent(/foo bar/)",
+    },
+    {
+      code: "expect(element.textContent).not.toMatch(/foo bar/)",
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: "expect(element).not.toHaveTextContent(/foo bar/)",
+    },
+
+    {
       code: 'expect(element.textContent).not.toMatch("foo")',
       errors: [
         {

--- a/src/rules/prefer-to-have-text-content.js
+++ b/src/rules/prefer-to-have-text-content.js
@@ -17,6 +17,7 @@ export const create = (context) => ({
   ) {
     const expectedArg = node.parent.parent.parent.arguments[0];
 
+    const expectedArgSource = context.getSourceCode().getText(expectedArg);
     context.report({
       node: node.parent,
       message: `Use toHaveTextContent instead of asserting on DOM node attributes`,
@@ -33,8 +34,10 @@ export const create = (context) => ({
           fixer.replaceTextRange(
             expectedArg.range,
             expectedArg.type === "Literal"
-              ? `/${expectedArg.value}/`
-              : `new RegExp(${context.getSourceCode().getText(expectedArg)})`
+              ? expectedArg.regex
+                ? expectedArgSource
+                : `/${expectedArg.value}/`
+              : `new RegExp(${expectedArgSource})`
           ),
         ];
       },
@@ -74,6 +77,7 @@ export const create = (context) => ({
     node
   ) {
     const expectedArg = node.parent.parent.parent.parent.arguments[0];
+    const expectedArgSource = context.getSourceCode().getText(expectedArg);
     context.report({
       node: node.parent,
       message: `Use toHaveTextContent instead of asserting on DOM node attributes`,
@@ -86,8 +90,10 @@ export const create = (context) => ({
         fixer.replaceTextRange(
           expectedArg.range,
           expectedArg.type === "Literal"
-            ? `/${expectedArg.value}/`
-            : `new RegExp(${context.getSourceCode().getText(expectedArg)})`
+            ? expectedArg.regex
+              ? expectedArgSource
+              : `/${expectedArg.value}/`
+            : `new RegExp(${expectedArgSource})`
         ),
       ],
     });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: improve autofixing in prefer-to-have-text-content

<!-- Why are these changes necessary? -->

**Why**: fixes #53 fixes #52 

<!-- How were these changes implemented? -->

**How**: more use of getText()

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->