### PR TITLE
fix: escape special chars in regex for toHaveTextContent fixer

### DIFF
--- a/src/__tests__/lib/rules/prefer-to-have-text-content.js
+++ b/src/__tests__/lib/rules/prefer-to-have-text-content.js
@@ -85,6 +85,26 @@ ruleTester.run("prefer-to-have-text-content", rule, {
       output: `expect(element).toHaveTextContent(/foo/)`,
     },
     {
+      code: 'expect(element.textContent).toContain("$42/month?")',
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: "expect(element).toHaveTextContent(/\\$42\\/month\\?/)",
+    },
+    {
+      code: "expect(element.textContent).toContain(100)",
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: `expect(element).toHaveTextContent(/100/)`,
+    },
+    {
       code: 'expect(container.firstChild.textContent).toContain("foo")',
       errors: [
         {
@@ -165,7 +185,6 @@ ruleTester.run("prefer-to-have-text-content", rule, {
       ],
       output: "expect(element).not.toHaveTextContent(/foo bar/)",
     },
-
     {
       code: 'expect(element.textContent).not.toMatch("foo")',
       errors: [
@@ -175,6 +194,16 @@ ruleTester.run("prefer-to-have-text-content", rule, {
         },
       ],
       output: `expect(element).not.toHaveTextContent(/foo/)`,
+    },
+    {
+      code: 'expect(element.textContent).not.toMatch("$42/month?")',
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: `expect(element).not.toHaveTextContent(/\\$42\\/month\\?/)`,
     },
   ],
 });

--- a/src/rules/prefer-to-have-text-content.js
+++ b/src/rules/prefer-to-have-text-content.js
@@ -36,7 +36,11 @@ export const create = (context) => ({
             expectedArg.type === "Literal"
               ? expectedArg.regex
                 ? expectedArgSource
-                : `/${expectedArg.value}/`
+                : new RegExp(
+                    expectedArg.value
+                      .toString()
+                      .replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&")
+                  )
               : `new RegExp(${expectedArgSource})`
           ),
         ];
@@ -92,7 +96,11 @@ export const create = (context) => ({
           expectedArg.type === "Literal"
             ? expectedArg.regex
               ? expectedArgSource
-              : `/${expectedArg.value}/`
+              : new RegExp(
+                  expectedArg.value
+                    .toString()
+                    .replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&")
+                )
             : `new RegExp(${expectedArgSource})`
         ),
       ],


### PR DESCRIPTION
**What**:

- Escape (RegExp) special characters in strings that are treated as regular expressions in the fixer for `toHaveTextContent`.
- Convert non-strings (eg: `100`) to a string before converting to a RegExp.

**Why**:

So the fixer works out-of-the-box without any additional manual fixes.

**How**:

- Using the snippet from MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
- Other relevant Stack Overflow answers:
    - https://stackoverflow.com/a/6969486/2690790
    - https://stackoverflow.com/a/3561711/2690790

**Checklist**:

- [ ] Documentation (N/A)
- [x] Tests
- [x] Ready to be merged
