### PR TITLE
fix(prefer-empty): don't report on non empty template strings in to-be-empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",
     "rules": {
-      "babel/quotes": "off"
+      "babel/quotes": "off",
+      "max-lines-per-function": "off"
     }
   },
   "eslintIgnore": [

--- a/src/__tests__/lib/rules/prefer-empty.js
+++ b/src/__tests__/lib/rules/prefer-empty.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-template-curly-in-string */
 /**
  * @fileoverview Prefer toBeEmptyDOMElement over checking innerHTML
  * @author Ben Monro
@@ -14,13 +15,15 @@ import * as rule from "../../../rules/prefer-empty";
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 ruleTester.run("prefer-empty", rule, {
   valid: [
     `expect(element.innerHTML).toBe('foo')`,
     `expect(element.innerHTML).toBe(foo)`,
     `expect(element.innerHTML).not.toBe('foo')`,
     `expect(element.innerHTML).not.toBe(foo)`,
+    "expect(statusText.innerHTML).toBe(`${value}%`)",
+    "expect(statusText.innerHTML).not.toBe(`${value}%`)",
     `expect(element.firstChild).toBe('foo')`,
     `expect(element.firstChild).not.toBe('foo')`,
     `expect(getByText("foo").innerHTML).toBe('foo')`,
@@ -104,6 +107,15 @@ ruleTester.run("prefer-empty", rule, {
       ],
       output: `expect(element).toBeEmptyDOMElement()`,
     },
+    {
+      code: "expect(element.innerHTML).toBe(``)",
+      errors: [
+        {
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
+        },
+      ],
+      output: `expect(element).toBeEmptyDOMElement()`,
+    },
 
     {
       code: `expect(element.innerHTML).toBe(null)`,
@@ -126,6 +138,15 @@ ruleTester.run("prefer-empty", rule, {
 
     {
       code: `expect(element.innerHTML).not.toBe('')`,
+      errors: [
+        {
+          message: "Use toBeEmptyDOMElement instead of checking inner html.",
+        },
+      ],
+      output: `expect(element).not.toBeEmptyDOMElement()`,
+    },
+    {
+      code: "expect(element.innerHTML).not.toBe(``)",
       errors: [
         {
           message: "Use toBeEmptyDOMElement instead of checking inner html.",

--- a/src/rules/prefer-empty.js
+++ b/src/rules/prefer-empty.js
@@ -56,7 +56,11 @@ export const create = (context) => ({
     node
   ) {
     const args = node.parent.parent.parent.arguments[0];
-    if (args.value || args.name) {
+    if (
+      args.value ||
+      args.name ||
+      (args.expressions && args.expressions.length)
+    ) {
       return;
     }
 
@@ -74,7 +78,11 @@ export const create = (context) => ({
     node
   ) {
     const args = node.parent.parent.parent.parent.arguments[0];
-    if (args.value || args.name) {
+    if (
+      args.value ||
+      args.name ||
+      (args.expressions && args.expressions.length)
+    ) {
       return;
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->
fixes bug that was reporting errors on non empty template strings in prefer-empty.
**Why**:
https://github.com/testing-library/eslint-plugin-jest-dom/issues/61#issuecomment-669211003
<!-- How were these changes implemented? -->

**How**:
added check for expressions.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->