### PR TITLE
fix: make sure prefer-in-document only lint queries

### DIFF
--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -35,11 +35,8 @@ const valid = [
   ]),
   `expect(screen.notAQuery('foo-bar')).toHaveLength(1)`,
   `expect(screen.getByText('foo-bar')).toHaveLength(2)`,
-
-  `expect(foo).toBeDefined();`,
-  `expect(foo).not.toBeDefined();`,
-  `expect(foo).toBeNull();`,
-  `expect(foo).not.toBeNull();`,
+  `expect(undefinedVariable).toBeDefined()`,
+  `expect([1,2,3]).toHaveLength(1);`,
 ];
 const invalid = [
   // Invalid cases that applies to all variants
@@ -55,6 +52,14 @@ const invalid = [
     invalidCase(
       `expect(wrapper.${q}('foo')).toHaveLength(1)`,
       `expect(wrapper.${q}('foo')).toBeInTheDocument()`
+    ),
+    invalidCase(
+      `const element = screen.${q}('foo'); expect(element).toHaveLength(1);`,
+      `const element = screen.${q}('foo'); expect(element).toBeInTheDocument();`
+    ),
+    invalidCase(
+      `const element = ${q}('foo'); expect(element).toBeNull();`,
+      `const element = ${q}('foo'); expect(element).not.toBeInTheDocument();`
     ),
   ]),
   // Invalid cases that applies to queryBy* and queryAllBy*

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -35,7 +35,11 @@ const valid = [
   ]),
   `expect(screen.notAQuery('foo-bar')).toHaveLength(1)`,
   `expect(screen.getByText('foo-bar')).toHaveLength(2)`,
-  `const element = screen.findByText('lorem ipsum'); expect(element).toBeDefined();`,
+
+  `expect(foo).toBeDefined();`,
+  `expect(foo).not.toBeDefined();`,
+  `expect(foo).toBeNull();`,
+  `expect(foo).not.toBeNull();`,
 ];
 const invalid = [
   // Invalid cases that applies to all variants

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -35,6 +35,7 @@ const valid = [
   ]),
   `expect(screen.notAQuery('foo-bar')).toHaveLength(1)`,
   `expect(screen.getByText('foo-bar')).toHaveLength(2)`,
+  `const element = screen.findByText('lorem ipsum'); expect(element).toBeDefined();`,
 ];
 const invalid = [
   // Invalid cases that applies to all variants

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -29,14 +29,18 @@ function isAntonymMatcher(matcherNode, matcherArguments) {
 
 function check(
   context,
-  { queryNode, matcherNode, matcherArguments, negatedMatcher }
+  { subject, matcherNode, matcherArguments, negatedMatcher }
 ) {
-  const query = queryNode.name || queryNode.property.name;
+  if (subject.type !== "CallExpression") {
+    return;
+  }
 
   // toHaveLength() is only invalid with 0 or 1
   if (matcherNode.name === "toHaveLength" && matcherArguments[0].value > 1) {
     return;
   }
+
+  const query = subject.callee.name || subject.callee.property.name;
 
   if (queries.includes(query)) {
     context.report({
@@ -82,13 +86,13 @@ export const create = (context) => {
     [`CallExpression[callee.object.object.callee.name='expect'][callee.object.property.name='not'][callee.property.name=${alternativeMatchers}]`](
       node
     ) {
-      const queryNode = node.callee.object.object.arguments[0].callee;
+      const subject = node.callee.object.object.arguments[0];
       const matcherNode = node.callee.property;
       const matcherArguments = node.arguments;
 
       check(context, {
         negatedMatcher: true,
-        queryNode,
+        subject,
         matcherNode,
         matcherArguments,
       });
@@ -98,13 +102,13 @@ export const create = (context) => {
     [`CallExpression[callee.object.callee.name='expect'][callee.property.name=${alternativeMatchers}]`](
       node
     ) {
-      const queryNode = node.callee.object.arguments[0].callee;
+      const subject = node.callee.object.arguments[0];
       const matcherNode = node.callee.property;
       const matcherArguments = node.arguments;
 
       check(context, {
         negatedMatcher: false,
-        queryNode,
+        subject,
         matcherNode,
         matcherArguments,
       });


### PR DESCRIPTION
**What**:

Make sure the rule `prefer-in-document` only reports on what are actually queries from testing-library. If there's a variable passed to expect like so: `expect(element).toBeDefined()` we don't really know what the value is.

This change will make sure we only lint code like: `expect(screen.findByText('lorem ipsum')` and `expect(findByTextId('list-item')`

This solves #104 

**How**:

If `subject` is anything other than `CallExpression` the checker method bails early.

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Ready to be merged