### PR TITLE
fix(rules): Only report prefer-to-have-value errors on accepted queries

### DIFF
--- a/src/__tests__/lib/rules/prefer-to-have-value.js
+++ b/src/__tests__/lib/rules/prefer-to-have-value.js
@@ -21,7 +21,7 @@ const errors = [{ messageId: "use-to-have-value" }];
 ruleTester.run("prefer-to-have-value", rule, {
   valid: [
     `expect(screen.getByRole("radio").value).toEqual("foo")`,
-    `expect(screen.queryAllByRole("checkbox").value).toStrictEqual("foo")`,
+    `expect(screen.queryAllByRole("checkbox")[0].value).toStrictEqual("foo")`,
     `async function x() { expect((await screen.findByRole("button")).value).toBe("foo") }`,
 
     `expect(element).toHaveValue('foo')`,
@@ -39,7 +39,7 @@ ruleTester.run("prefer-to-have-value", rule, {
     expect(element.value).toBe('foo');`,
 
     `expect(screen.getByRole("radio").value).not.toEqual("foo")`,
-    `expect(screen.queryAllByRole("checkbox").value).not.toStrictEqual("foo")`,
+    `expect(screen.queryAllByRole("checkbox")[0].value).not.toStrictEqual("foo")`,
     `async function x() { expect((await screen.findByRole("button")).value).not.toBe("foo") }`,
 
     `const element = document.getElementById('asdfasf');

--- a/src/__tests__/lib/rules/prefer-to-have-value.js
+++ b/src/__tests__/lib/rules/prefer-to-have-value.js
@@ -20,6 +20,10 @@ const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2020 } });
 const errors = [{ messageId: "use-to-have-value" }];
 ruleTester.run("prefer-to-have-value", rule, {
   valid: [
+    `expect(screen.getByRole("radio").value).toEqual("foo")`,
+    `expect(screen.queryAllByRole("checkbox").value).toStrictEqual("foo")`,
+    `async function x() { expect((await screen.findByRole("button")).value).toBe("foo") }`,
+
     `expect(element).toHaveValue('foo')`,
     `expect(element.value).toBeGreaterThan(2);`,
     `expect(element.value).toBeLessThan(2);`,
@@ -33,6 +37,10 @@ ruleTester.run("prefer-to-have-value", rule, {
 
     `const element = { value: 'foo' };
     expect(element.value).toBe('foo');`,
+
+    `expect(screen.getByRole("radio").value).not.toEqual("foo")`,
+    `expect(screen.queryAllByRole("checkbox").value).not.toStrictEqual("foo")`,
+    `async function x() { expect((await screen.findByRole("button")).value).not.toBe("foo") }`,
 
     `const element = document.getElementById('asdfasf');
     expect(element.value).not.toEqual('foo');`,
@@ -105,119 +113,6 @@ ruleTester.run("prefer-to-have-value", rule, {
       code: `const element = screen.getByRole("textbox"); expect(element.value).not.toBe("foo");`,
       errors,
       output: `const element = screen.getByRole("textbox"); expect(element).not.toHaveValue("foo");`,
-    },
-    //==========================================================================
-    {
-      code: `expect(screen.getByTestId('bananas').value).toEqual('foo')`,
-      errors: [
-        {
-          ...errors[0],
-          suggestions: [
-            {
-              desc: "Replace toEqual with toHaveValue",
-              output: `expect(screen.getByTestId('bananas')).toHaveValue('foo')`,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `expect(screen.queryByTestId('bananas').value).toBe('foo')`,
-      errors: [
-        {
-          ...errors[0],
-          suggestions: [
-            {
-              desc: "Replace toBe with toHaveValue",
-              output: `expect(screen.queryByTestId('bananas')).toHaveValue('foo')`,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `async function x() { expect((await screen.findByTestId("bananas")).value).toStrictEqual("foo") }`,
-      errors: [
-        {
-          ...errors[0],
-          suggestions: [
-            {
-              desc: "Replace toStrictEqual with toHaveValue",
-              output: `async function x() { expect((await screen.findByTestId("bananas"))).toHaveValue("foo") }`,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `let element; element = screen.getByTestId('bananas'); expect(element.value).toEqual('foo');`,
-      errors: [
-        {
-          ...errors[0],
-          suggestions: [
-            {
-              desc: "Replace toEqual with toHaveValue",
-              output: `let element; element = screen.getByTestId('bananas'); expect(element).toHaveValue('foo');`,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `expect(screen.getByTestId('bananas').value).not.toEqual('foo')`,
-      errors: [
-        {
-          ...errors[0],
-          suggestions: [
-            {
-              desc: "Replace toEqual with toHaveValue",
-              output: `expect(screen.getByTestId('bananas')).not.toHaveValue('foo')`,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `expect(screen.queryByTestId('bananas').value).not.toBe('foo')`,
-      errors: [
-        {
-          ...errors[0],
-          suggestions: [
-            {
-              desc: "Replace toBe with toHaveValue",
-              output: `expect(screen.queryByTestId('bananas')).not.toHaveValue('foo')`,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `async function x() { expect((await screen.findByTestId("bananas")).value).not.toStrictEqual("foo") }`,
-      errors: [
-        {
-          ...errors[0],
-          suggestions: [
-            {
-              desc: "Replace toStrictEqual with toHaveValue",
-              output: `async function x() { expect((await screen.findByTestId("bananas"))).not.toHaveValue("foo") }`,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `let element; element = screen.getByTestId('bananas'); expect(element.value).not.toEqual('foo');`,
-      errors: [
-        {
-          ...errors[0],
-          suggestions: [
-            {
-              desc: "Replace toEqual with toHaveValue",
-              output: `let element; element = screen.getByTestId('bananas'); expect(element).not.toHaveValue('foo');`,
-            },
-          ],
-        },
-      ],
     },
   ],
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Only report errors for prefer-to-have-values if the query node is one of the accepted queries for toHaveValue i.e. a `ByRole("textdown")` or a `ByRole("dropdown")` query. Fixes #131 
<!-- Why are these changes necessary? -->

**Why**:
Avoid reporting errors unless we know that the assertion is definitely erroneous.
<!-- How were these changes implemented? -->

**How**:
Check to see that the query and the query argument is valid before reporting an error.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
