### PR TITLE
Matches toBe(null) and toEqual(null) in addition to toBeNull() in prefer-document

### DIFF
--- a/docs/rules/prefer-in-document.md
+++ b/docs/rules/prefer-in-document.md
@@ -15,6 +15,10 @@ expect(wrapper.queryByText("foo")).toHaveLength(1);
 expect(queryByText("foo")).toHaveLength(0);
 expect(queryByText("foo")).toBeNull();
 expect(queryByText("foo")).not.toBeNull();
+expect(queryByText("foo")).toBe(null);
+expect(queryByText("foo")).not.toBe(null);
+expect(queryByText("foo")).toEqual(null);
+expect(queryByText("foo")).not.toEqual(null);
 expect(queryByText("foo")).toBeDefined();
 expect(queryByText("foo")).not.toBeDefined();
 

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -82,6 +82,8 @@ const valid = [
   `import {NUM_BUTTONS} from "./foo";
      expect(screen.getByText('foo')).toHaveLength(NUM_BUTTONS)`,
   `expect(screen.getAllByText("foo")).toHaveLength(getLength())`,
+  `expect(screen.getAllByText("foo")).toBe(foo)`,
+  `expect(screen.getAllByText("foo")).toEqual(foo)`,
 ];
 const invalid = [
   invalidCase(
@@ -237,6 +239,22 @@ const invalid = [
   ),
   invalidCase(
     `expect(queryByText('foo')) .not .toBeNull()`,
+    `expect(queryByText('foo')).toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(queryByText('foo')).toBe(null)`,
+    `expect(queryByText('foo')).not.toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(queryByText('foo')).not.toBe(null)`,
+    `expect(queryByText('foo')).toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(queryByText('foo')).toEqual(null)`,
+    `expect(queryByText('foo')).not.toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(queryByText('foo')).not.toEqual(null)`,
     `expect(queryByText('foo')).toBeInTheDocument()`
   ),
   invalidCase(


### PR DESCRIPTION
Fixes #152
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] Documentation
- [X] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
