### PR TITLE
fix(prefer-in-document): check that a node has arguments before trying to access properties on them

### DIFF
--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -36,6 +36,7 @@ const valid = [
       foo = somethingElse;
       expect(foo).toHaveLength(1);`,
   ]),
+  `expect(myFunction()).toHaveLength();`,
   `let foo;
   foo = "bar";
   expect(foo).toHaveLength(1);`,

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -36,6 +36,8 @@ const valid = [
       foo = somethingElse;
       expect(foo).toHaveLength(1);`,
   ]),
+  `expect().not.toBeNull()`,
+  `expect(myFunction()).toBe();`,
   `expect(myFunction()).toHaveLength();`,
   `let foo;
   foo = "bar";

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -91,7 +91,10 @@ export const create = (context) => {
 
     // toBe() or toEqual() are only invalid with null
     if (matcherNode.name === "toBe" || matcherNode.name === "toEqual") {
-      if (!usesToBeOrToEqualWithNull(matcherNode, matcherArguments)) {
+      if (
+        !matcherArguments.length ||
+        !usesToBeOrToEqualWithNull(matcherNode, matcherArguments)
+      ) {
         return;
       }
     }
@@ -148,6 +151,10 @@ export const create = (context) => {
     [`CallExpression[callee.object.object.callee.name='expect'][callee.object.property.name='not'][callee.property.name=${alternativeMatchers}], CallExpression[callee.object.callee.name='expect'][callee.object.property.name='not'][callee.object.arguments.0.argument.callee.name=${alternativeMatchers}]`](
       node
     ) {
+      if (!node.callee.object.object.arguments.length) {
+        return;
+      }
+
       const arg = node.callee.object.object.arguments[0];
       const queryNode =
         arg.type === "AwaitExpression" ? arg.argument.callee : arg.callee;

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -32,8 +32,10 @@ function isAntonymMatcher(matcherNode, matcherArguments) {
 }
 
 function usesToBeOrToEqualWithNull(matcherNode, matcherArguments) {
-  return (matcherNode.name === "toBe" || matcherNode.name === "toEqual") &&
-    matcherArguments[0].value === null;
+  return (
+    (matcherNode.name === "toBe" || matcherNode.name === "toEqual") &&
+    matcherArguments[0].value === null
+  );
 }
 
 function usesToHaveLengthZero(matcherNode, matcherArguments) {
@@ -71,7 +73,7 @@ export const create = (context) => {
     if (!queryNode || (!queryNode.name && !queryNode.property)) return;
 
     // toHaveLength() is only invalid with 0 or 1
-    if (matcherNode.name === "toHaveLength") {
+    if (matcherNode.name === "toHaveLength" && matcherArguments.length) {
       const lengthValue = getLengthValue(matcherArguments);
       // isNotToHaveLengthZero represents .not.toHaveLength(0) which is a valid use of toHaveLength
       const isNotToHaveLengthZero =


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

It seems that `prefer-in-document` crashes in situations where it expected nodes to have an argument but they actually don't.

<!-- Why are these changes necessary? -->

**Why**:
The rule assumes that if it's found the node its looking for, then the node has to have arguments and so makes property access keys in the first item in the args array without actually checking if its defined.

<!-- How were these changes implemented? -->

**How**:

I've added checks for the argument length before attempts to access said arguments.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
