### PR TITLE
fix(createBannedAttributeRule): check arguments length before accessing

### DIFF
--- a/src/__tests__/__fixtures__/createBannedAttributeTestCases.js
+++ b/src/__tests__/__fixtures__/createBannedAttributeTestCases.js
@@ -4,6 +4,15 @@ export default ({ preferred, negatedPreferred, attribute }) => {
   const doubleNegativeCases = negatedPreferred.startsWith("toBe")
     ? [
         {
+          code: `expect().not.${negatedPreferred}`,
+          errors: [
+            {
+              message: `Use ${preferred} instead of not.${negatedPreferred}`,
+            },
+          ],
+          output: `expect().${preferred}`,
+        },
+        {
           code: `const el = screen.getByText("foo"); expect(el).not.${negatedPreferred}`,
           errors: [
             {
@@ -66,6 +75,7 @@ export default ({ preferred, negatedPreferred, attribute }) => {
 
   return {
     valid: [
+      `expect().not.toHaveProperty('value', 'foo')`,
       `const el = screen.getByText("foo"); expect(el).not.toHaveProperty('value', 'foo')`,
       `const el = screen.getByText("foo"); expect(el).${preferred}`,
       `const el = screen.getByText("foo"); expect(el).${negatedPreferred}`,

--- a/src/createBannedAttributeRule.js
+++ b/src/createBannedAttributeRule.js
@@ -13,6 +13,7 @@ export default ({ preferred, negatedPreferred, attributes }) => (context) => {
       : negatedPreferred;
 
   const isBannedArg = (node) =>
+    node.arguments.length &&
     attributes.some((attr) => attr === node.arguments[0].value);
 
   //expect(el).not.toBeEnabled() => expect(el).toBeDisabled()
@@ -42,6 +43,10 @@ export default ({ preferred, negatedPreferred, attributes }) => (context) => {
     "CallExpression[callee.property.name=/toBe(Truthy|Falsy)?|toEqual/][callee.object.callee.name='expect']"(
       node
     ) {
+      if (!node.callee.object.arguments.length) {
+        return;
+      }
+
       const {
         arguments: [{ object, property, property: { name } = {} }],
       } = node.callee.object;
@@ -77,11 +82,11 @@ export default ({ preferred, negatedPreferred, attributes }) => (context) => {
     "CallExpression[callee.property.name=/toHaveProperty|toHaveAttribute/][callee.object.property.name='not'][callee.object.object.callee.name='expect']"(
       node
     ) {
-      const arg = node.arguments[0].value;
       if (!isBannedArg(node)) {
         return;
       }
 
+      const arg = node.arguments[0].value;
       const correctFunction = getCorrectFunctionFor(node, true);
 
       const incorrectFunction = node.callee.property.name;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

It seems that `createBannedAttributeRule` crashes in situations where it expected nodes to have an argument but they actually don't.

<!-- Why are these changes necessary? -->

**Why**:

The function assumes that if it's found the node its looking for, then the node has to have arguments and so makes property access keys in the first item in the args array without actually checking if its defined.

<!-- How were these changes implemented? -->

**How**:

I added a length check on the arguments the matcher has.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Fixes #127