### PR TITLE
feat: [prefer-in-document] Detect and auto-fix `toBeFalsy()` and `toBeTruthy()`

### DIFF
--- a/docs/rules/prefer-in-document.md
+++ b/docs/rules/prefer-in-document.md
@@ -21,6 +21,10 @@ expect(queryByText("foo")).toEqual(null);
 expect(queryByText("foo")).not.toEqual(null);
 expect(queryByText("foo")).toBeDefined();
 expect(queryByText("foo")).not.toBeDefined();
+expect(queryByText("foo")).toBeTruthy();
+expect(queryByText("foo")).not.toBeTruthy();
+expect(queryByText("foo")).toBeFalsy();
+expect(queryByText("foo")).not.toBeFalsy();
 
 const foo = screen.getByText("foo");
 expect(foo).toHaveLength(1);

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -269,6 +269,22 @@ const invalid = [
     `expect(queryByText('foo')) .not .toBeInTheDocument()`
   ),
   invalidCase(
+    `expect(queryByText('foo')).toBeFalsy()`,
+    `expect(queryByText('foo')).not.toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(queryByText('foo')).not.toBeFalsy()`,
+    `expect(queryByText('foo')).toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(queryByText('foo')).toBeTruthy()`,
+    `expect(queryByText('foo')).toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(queryByText('foo')).not.toBeTruthy()`,
+    `expect(queryByText('foo')).not.toBeInTheDocument()`
+  ),
+  invalidCase(
     `let foo;
       foo = screen.queryByText('foo');
       expect(foo).toHaveLength(0);`,

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -26,6 +26,7 @@ export const meta = {
 function isAntonymMatcher(matcherNode, matcherArguments) {
   return (
     matcherNode.name === "toBeNull" ||
+    matcherNode.name === "toBeFalsy" ||
     usesToBeOrToEqualWithNull(matcherNode, matcherArguments) ||
     usesToHaveLengthZero(matcherNode, matcherArguments)
   );
@@ -43,7 +44,7 @@ function usesToHaveLengthZero(matcherNode, matcherArguments) {
 }
 
 export const create = (context) => {
-  const alternativeMatchers = /^(toHaveLength|toBeDefined|toBeNull|toBe|toEqual)$/;
+  const alternativeMatchers = /^(toHaveLength|toBeDefined|toBeNull|toBe|toEqual|toBeTruthy|toBeFalsy)$/;
   function getLengthValue(matcherArguments) {
     let lengthValue;
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Autofix `toBeFalsy()` to `not.toBeInTheDocument()` and `toBeTruthy()` to `toBeInTheDocument()`.

<!-- Why are these changes necessary? -->

**Why**: I noticed in our test code an occurrence of `expect(queryByText(XXX)).toBeFalsy()` which I think should be detected by this plugin.

<!-- How were these changes implemented? -->

**How**: I merely updated existing code.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] Documentation
- [X] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
