### PR TITLE
fix(prefer-to-have-attribute): Handle case where matcher value is empty string

### DIFF
--- a/src/__tests__/lib/rules/prefer-to-have-attribute.js
+++ b/src/__tests__/lib/rules/prefer-to-have-attribute.js
@@ -73,6 +73,24 @@ ruleTester.run("prefer-to-have-attribute", rule, {
       output: `expect(getByText("yes")).toHaveAttribute("data-blah", expect.stringMatching(/foo/))`,
     },
     {
+      code: `expect(getByText("yes").getAttribute("data-blah")).toBe("")`,
+      errors: [
+        {
+          message: "Use toHaveAttribute instead of asserting on getAttribute",
+        },
+      ],
+      output: `expect(getByText("yes")).toHaveAttribute("data-blah", "")`,
+    },
+    {
+      code: `expect(getByText("yes").getAttribute("data-blah")).toBe('')`,
+      errors: [
+        {
+          message: "Use toHaveAttribute instead of asserting on getAttribute",
+        },
+      ],
+      output: `expect(getByText("yes")).toHaveAttribute("data-blah", '')`,
+    },
+    {
       code: `expect(getByText('foo').hasAttribute('foo')).toBe(null)`,
       errors: [
         {
@@ -172,6 +190,24 @@ ruleTester.run("prefer-to-have-attribute", rule, {
       output: 'expect(element).toHaveAttribute("foo", "bar")',
     },
     {
+      code: `expect(getByText("yes").getAttribute("data-blah")).toEqual("")`,
+      errors: [
+        {
+          message: "Use toHaveAttribute instead of asserting on getAttribute",
+        },
+      ],
+      output: `expect(getByText("yes")).toHaveAttribute("data-blah", "")`,
+    },
+    {
+      code: `expect(getByText("yes").getAttribute("data-blah")).toEqual('')`,
+      errors: [
+        {
+          message: "Use toHaveAttribute instead of asserting on getAttribute",
+        },
+      ],
+      output: `expect(getByText("yes")).toHaveAttribute("data-blah", '')`,
+    },
+    {
       code: 'expect(element.getAttribute("foo")).toStrictEqual("bar")',
       errors: [
         {
@@ -179,6 +215,24 @@ ruleTester.run("prefer-to-have-attribute", rule, {
         },
       ],
       output: 'expect(element).toHaveAttribute("foo", "bar")',
+    },
+    {
+      code: `expect(getByText("yes").getAttribute("data-blah")).toStrictEqual("")`,
+      errors: [
+        {
+          message: "Use toHaveAttribute instead of asserting on getAttribute",
+        },
+      ],
+      output: `expect(getByText("yes")).toHaveAttribute("data-blah", "")`,
+    },
+    {
+      code: `expect(getByText("yes").getAttribute("data-blah")).toStrictEqual('')`,
+      errors: [
+        {
+          message: "Use toHaveAttribute instead of asserting on getAttribute",
+        },
+      ],
+      output: `expect(getByText("yes")).toHaveAttribute("data-blah", '')`,
     },
     {
       code: 'expect(element.getAttribute("foo")).toBe(null)',

--- a/src/rules/prefer-to-have-attribute.js
+++ b/src/rules/prefer-to-have-attribute.js
@@ -64,15 +64,14 @@ export const create = (context) => ({
     node
   ) {
     const arg = node.parent.parent.parent.arguments;
-    const isNullOrEmpty =
-      arg.length > 0 && (arg[0].value === null || arg[0].value === "");
+    const isNull = arg.length > 0 && arg[0].value === null;
 
     const sourceCode = context.getSourceCode();
     context.report({
       node: node.parent,
       message: `Use toHaveAttribute instead of asserting on getAttribute`,
       fix: (fixer) => {
-        const lastFixer = isNullOrEmpty
+        const lastFixer = isNull
           ? fixer.replaceText(
               node.parent.parent.parent.arguments[0],
               sourceCode.getText(node.arguments[0])
@@ -86,7 +85,7 @@ export const create = (context) => ({
           fixer.removeRange([node.callee.object.range[1], node.range[1]]),
           fixer.replaceText(
             node.parent.parent.property,
-            `${isNullOrEmpty ? "not." : ""}toHaveAttribute`
+            `${isNull ? "not." : ""}toHaveAttribute`
           ),
           lastFixer,
         ];


### PR DESCRIPTION
**What**:

Bugfix to handle case where in circumstances that the matcher value has been intended as an empty string, the fixer incorrectly assumes the `.not` case.

**Why**:

The purpose of this fix is so that the code fixer can correctly match empty string attributes as differentiated from null or missing values.

**How**:

Do not treat an empty string as a null value.

**Checklist**:

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

Feel free to merge if approved.