### PR TITLE
test: remove `jest-extended` usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "eslint": "^7.31.0",
     "eslint-remote-tester": "^2.0.1",
     "eslint-remote-tester-repositories": "^0.0.3",
-    "jest-extended": "^0.11.5",
     "kcd-scripts": "^11.2.2",
     "typescript": "^4.5.3"
   },

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,5 +1,4 @@
-import { rules, generateRecommendedConfig } from "../index";
-import "jest-extended";
+import { generateRecommendedConfig, rules } from "../";
 
 it("should have all the rules", () => {
   expect(Object.keys(rules).length).toBeGreaterThan(0);
@@ -8,9 +7,9 @@ it("should have all the rules", () => {
 it.each(Object.keys(rules))("%s should export required fields", (ruleName) => {
   const rule = rules[ruleName];
   expect(rule).toHaveProperty("create", expect.any(Function));
-  expect(rule.meta.docs.url).not.toBeEmpty();
+  expect(rule.meta.docs.url).not.toBe("");
   expect(rule.meta.docs.category).toBe("Best Practices");
-  expect(rule.meta.docs.description).not.toBeEmpty();
+  expect(rule.meta.docs.description).not.toBe("");
 });
 
 it("should have a recommended config with recommended rules", () => {


### PR DESCRIPTION
As requested by @G-Rath in https://github.com/testing-library/eslint-plugin-jest-dom/pull/200#issuecomment-979395884

Closes #228