### PR TITLE
feat: drop Node 10 support

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         eslint: [6.8.0, 6, 7.0.0, 7]
-        node: [12, 14, 16]
+        node: [12.22.0, 12, 14.17.0, 14, 16.0.0, 16]
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-remote-tester-results"
   ],
   "engines": {
-    "node": "^10.12.0 || >=12.0.0",
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
     "npm": ">=6",
     "yarn": ">=1"
   }


### PR DESCRIPTION
- If we want to update our `@testing-library/dom` dependency to v8, we also need `Node@>=12`
  https://github.com/testing-library/dom-testing-library/blob/1fc17bec5d28e5b58fcdd325d6d2caaff02dfb47/package.json#L23-L25

- If we want to update our `@typescript-eslint/parser` dependency to v5, we also need `Node@^12.22.0 || ^14.17.0 || >=16.0.0`
  https://github.com/typescript-eslint/typescript-eslint/blob/b9407c560c8ab625fd546af73f71cce8178b9e05/package.json#L55-L57

- Node 10 is EOL, so it's a good practice to not support it anymore.

- ESLint 8.x requires `Node@^12.22.0 || ^14.17.0 || >=16.0.0` and imo it's a good practice to keep the Node version equal to that of the latest supported ESLint version
  https://github.com/eslint/eslint/blob/fa4d4830a0e77f92154079ada17ffb893ce64232/package.json#L146-L148

---

BREAKING CHANGE: Requires Node@^12.22.0 || ^14.17.0 || >=16.0.0

As requested by @G-Rath in https://github.com/testing-library/eslint-plugin-jest-dom/pull/200#issuecomment-979395884

This branch is dependent on #237