### PR TITLE
fix(prefer-in-document): check that argument exists before accessing

### DIFF
--- a/src/__tests__/lib/rules/prefer-empty.js
+++ b/src/__tests__/lib/rules/prefer-empty.js
@@ -18,6 +18,7 @@ import * as rule from "../../../rules/prefer-empty";
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 ruleTester.run("prefer-empty", rule, {
   valid: [
+    `expect().toBe(true)`,
     `expect(element.innerHTML).toBe('foo')`,
     `expect(element.innerHTML).toBe(foo)`,
     `expect(element.innerHTML).toBe(foo + bar)`,

--- a/src/__tests__/lib/rules/prefer-focus.js
+++ b/src/__tests__/lib/rules/prefer-focus.js
@@ -9,6 +9,7 @@ import * as rule from "../../../rules/prefer-focus";
 const ruleTester = new RuleTester();
 ruleTester.run("prefer-focus", rule, {
   valid: [
+    `expect().toBe(true)`,
     `expect(input).not.toHaveFocus();`,
     `expect(input).toHaveFocus();`,
     `expect(document.activeElement).toBeNull()`,

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -27,6 +27,7 @@ function invalidCase(code, output) {
 }
 
 const valid = [
+  "expect().toBe(true)",
   ...["getByText", "getByRole"].map((q) => [
     `expect(screen.${q}('foo')).toBeInTheDocument()`,
     `expect(${q}('foo')).toBeInTheDocument()`,

--- a/src/__tests__/lib/rules/prefer-prefer-to-have-class.js
+++ b/src/__tests__/lib/rules/prefer-prefer-to-have-class.js
@@ -5,6 +5,7 @@ const errors = [{ messageId: "use-to-have-class" }];
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 ruleTester.run("prefer-to-have-class", rule, {
   valid: [
+    `expect().toBe(true)`,
     `const el = screen.getByText("foo"); expect(el).toHaveClass("bar")`,
     `const el = screen.getByText("foo"); expect(el.class).toEqual(foo)`,
     `const el = screen.getByText("foo"); expect(el).toHaveAttribute("class")`,

--- a/src/__tests__/lib/rules/prefer-to-have-attribute.js
+++ b/src/__tests__/lib/rules/prefer-to-have-attribute.js
@@ -18,6 +18,7 @@ import * as rule from "../../../rules/prefer-to-have-attribute";
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 ruleTester.run("prefer-to-have-attribute", rule, {
   valid: [
+    "expect().toBe(true)",
     "expect(element.foo).toBeTruthy()",
     "expect(element.getAttributeNode()).toBeNull()",
     `expect(element.getAttribute('foo')).toBeGreaterThan(2)`,
@@ -44,8 +45,7 @@ ruleTester.run("prefer-to-have-attribute", rule, {
       output: `expect(element).toHaveAttribute('foo', expect.stringContaining('bar'));`,
     },
     {
-      code:
-        "expect(element.getAttribute('foo')).toContain(`bar=${encodeURIComponent(baz.id)}`);",
+      code: "expect(element.getAttribute('foo')).toContain(`bar=${encodeURIComponent(baz.id)}`);",
       errors: [
         {
           message: "Use toHaveAttribute instead of asserting on getAttribute",

--- a/src/__tests__/lib/rules/prefer-to-have-style.js
+++ b/src/__tests__/lib/rules/prefer-to-have-style.js
@@ -7,6 +7,7 @@ const errors = [
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 ruleTester.run("prefer-to-have-style", rule, {
   valid: [
+    `expect().toBe(true)`,
     `expect(el).toHaveStyle({foo:"bar"})`,
     `expect(el.style).toMatchSnapshot()`,
     `expect(el.style).toEqual(foo)`,

--- a/src/__tests__/lib/rules/prefer-to-have-text-content.js
+++ b/src/__tests__/lib/rules/prefer-to-have-text-content.js
@@ -18,6 +18,7 @@ import * as rule from "../../../rules/prefer-to-have-text-content";
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 ruleTester.run("prefer-to-have-text-content", rule, {
   valid: [
+    `expect().toBe(true)`,
     `expect(string).toBe("foo")`,
     `expect(element).toHaveTextContent("foo")`,
     `expect(container.lastNode).toBe("foo")`,

--- a/src/__tests__/lib/rules/prefer-to-have-value.js
+++ b/src/__tests__/lib/rules/prefer-to-have-value.js
@@ -20,6 +20,7 @@ const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2020 } });
 const errors = [{ messageId: "use-to-have-value" }];
 ruleTester.run("prefer-to-have-value", rule, {
   valid: [
+    `expect().toBe(true)`,
     `expect(screen.getByRole("radio").value).toEqual("foo")`,
     `expect(screen.queryAllByRole("checkbox")[0].value).toStrictEqual("foo")`,
     `async function x() { expect((await screen.findByRole("button")).value).toBe("foo") }`,

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -44,7 +44,8 @@ function usesToHaveLengthZero(matcherNode, matcherArguments) {
 }
 
 export const create = (context) => {
-  const alternativeMatchers = /^(toHaveLength|toBeDefined|toBeNull|toBe|toEqual|toBeTruthy|toBeFalsy)$/;
+  const alternativeMatchers =
+    /^(toHaveLength|toBeDefined|toBeNull|toBe|toEqual|toBeTruthy|toBeFalsy)$/;
   function getLengthValue(matcherArguments) {
     let lengthValue;
 
@@ -216,6 +217,11 @@ export const create = (context) => {
       node
     ) {
       const arg = node.callee.object.arguments[0];
+
+      if (!arg) {
+        return;
+      }
+
       const queryNode =
         arg.type === "AwaitExpression" ? arg.argument.callee : arg.callee;
       const matcherNode = node.callee.property;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes a crash caught by #229 in `prefer-in-document`

<!-- Why are these changes necessary? -->

**Why**:

It assumes that `expect` calls have an argument, which semantically they should but syntactically is not correct.

<!-- How were these changes implemented? -->

**How**:

I've implemented a guard to ensure that the argument exists before trying to access any properties on it; have also added the test to the valid tests for every rule to ensure they can all handle the case.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
