### PR TITLE
fix(prefer-to-have-value): check that property exists before accessing

### DIFF
--- a/src/__tests__/lib/rules/prefer-to-have-value.js
+++ b/src/__tests__/lib/rules/prefer-to-have-value.js
@@ -51,6 +51,10 @@ ruleTester.run("prefer-to-have-value", rule, {
 
     `const element = { value: 'foo' };
     expect(element.value).not.toBe('foo');`,
+    `
+      const res = makePath()();
+      expect(res.value).toEqual('/repositories/create');
+    `,
   ],
   invalid: [
     {

--- a/src/assignment-ast.js
+++ b/src/assignment-ast.js
@@ -74,7 +74,9 @@ export function getQueryNodeFrom(context, nodeWithValueProp) {
     };
   }
 
-  const query = queryNode.callee.name || queryNode.callee.property.name;
+  const query =
+    queryNode.callee.name ||
+    (queryNode.callee.property && queryNode.callee.property.name);
   const queryArg = queryNode.arguments[0] && queryNode.arguments[0].value;
   const isDTLQuery = queries.includes(query);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes a crash caught by #229 in `prefer-to-have-value`

<!-- Why are these changes necessary? -->

**Why**:

It assumes that `property` will always be defined on the `queryNode` node if `callee.name` isn't, which is not always the case.

<!-- How were these changes implemented? -->

**How**:

I've implemented a guard to ensure that the property exists before trying to access it's `name`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
