### PR TITLE
fix: remove unneeded dependency on `@babel/runtime`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "validate": "kcd-scripts validate"
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
     "@testing-library/dom": "^7.31.2",
     "requireindex": "^1.2.0"
   },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Removes `@babel/runtime` as a dependency

<!-- Why are these changes necessary? -->

**Why**:

I can't find any place where we actually use it, and everything seems to be fine without it...

<!-- How were these changes implemented? -->

**How**:

`npm un @babel/runtime`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
