### PR TITLE
fix(prefer-in-document): don't crash on matchers that are not being called

### DIFF
--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -88,6 +88,15 @@ const valid = [
   `expect(screen.getAllByText("foo")).toHaveLength(getLength())`,
   `expect(screen.getAllByText("foo")).toBe(foo)`,
   `expect(screen.getAllByText("foo")).toEqual(foo)`,
+  `
+  const element =  getByText('value')
+  expect(element).toBeTruthy`,
+  `
+  const element =  getByText('value')
+  expect(element).toBe.truthy`,
+  `
+  const element =  getByText('value')
+  expect(element).toBeInTheDocument`,
 ];
 const invalid = [
   invalidCase(

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -71,6 +71,10 @@ export const create = (context) => {
     negatedMatcher,
     expect,
   }) {
+    if (matcherNode.parent.parent.type !== "CallExpression") {
+      return;
+    }
+
     // only report on dom nodes which we can resolve to RTL queries.
     if (!queryNode || (!queryNode.name && !queryNode.property)) return;
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Fixes #249