### PR TITLE
docs: add remaining recommended rules to config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ module.exports = {
     "jest-dom/prefer-enabled-disabled": "error",
     "jest-dom/prefer-required": "error",
     "jest-dom/prefer-to-have-attribute": "error",
+    "jest-dom/prefer-empty": "error",
+    "jest-dom/prefer-focus": "error",
+    "jest-dom/prefer-in-document": "error",
+    "jest-dom/prefer-to-have-class": "error",
+    "jest-dom/prefer-to-have-style": "error",
+    "jest-dom/prefer-to-have-text-content": "error",
+    "jest-dom/prefer-to-have-value": "error",
   },
 };
 ```


### PR DESCRIPTION
**What**:
Add rules, that are classified as recommended but are not currently listed in Readme (https://github.com/testing-library/eslint-plugin-jest-dom#usage), to the config example

**Why**:

Makes it easier to enable and disable rules, when not using the recommended settings

**How**:

Extracted all rules from `eslint-plugin-jest-dom/dist/rules`, that have the `recommended: true,` property (All of them basically)

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests "N/A"
- [x] Ready to be merged
      
