### PR TITLE
fix(prefer-in-document): false positive on .toHaveLength(1) matcher with *AllBy* query

### DIFF
--- a/docs/rules/prefer-in-document.md
+++ b/docs/rules/prefer-in-document.md
@@ -11,6 +11,7 @@
 This rule enforces checking existance of DOM nodes using `.toBeInTheDocument()`.
 The rule prefers that matcher over various existance checks such as `.toHaveLength(1)`, `.not.toBeNull()` and
 similar.
+However it's considered OK to use `.toHaveLength(value)` matcher with `*AllBy*` queries.
 
 Examples of **incorrect** code for this rule:
 
@@ -46,7 +47,7 @@ expect(screen.getByText("foo").length).toBe(1);
 expect(screen.queryByText("foo")).toBeInTheDocument();
 expect(await screen.findByText("foo")).toBeInTheDocument();
 expect(queryByText("foo")).toBeInTheDocument();
-expect(wrapper.queryAllByTestId("foo")).toBeInTheDocument();
+expect(wrapper.queryAllByTestId("foo")).toHaveLength(1);
 expect(screen.getAllByLabel("foo-bar")).toHaveLength(2);
 expect(notAQuery("foo-bar")).toHaveLength(1);
 

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -98,7 +98,7 @@ const valid = [
   const element =  getByText('value')
   expect(element).toBeInTheDocument`,
 
-  // *AllBy queries with `.toHaveLength(1)` is valid
+  // *AllBy* queries with `.toHaveLength(1)` is valid
   // see conclusion at https://github.com/testing-library/eslint-plugin-jest-dom/issues/171#issuecomment-895074086
   `expect(screen.getAllByRole('foo')).toHaveLength(1)`,
   `expect(await screen.findAllByRole('foo')).toHaveLength(1)`,
@@ -114,6 +114,14 @@ const valid = [
   `let foo;
     foo = screen.getAllByRole('foo');
     expect(foo).toHaveLength(1);`,
+
+  // *AllBy* queries with `.toHaveLength(0)` is valid
+  // see conclusion at https://github.com/testing-library/eslint-plugin-jest-dom/issues/171#issuecomment-895074086
+  `expect(screen.queryAllByTestId("foo")).toHaveLength(0)`,
+  `expect(queryAllByText('foo')).toHaveLength(0)`,
+  `let foo;
+    foo = screen.queryAllByText('foo');
+    expect(foo).toHaveLength(0);`,
 ];
 const invalid = [
   invalidCase(
@@ -127,10 +135,6 @@ const invalid = [
      expect(screen.getByText('foo')).toBeInTheDocument()`
   ),
 
-  invalidCase(
-    `expect(screen.queryAllByTestId("foo")).toHaveLength(0)`,
-    `expect(screen.queryByTestId("foo")).not.toBeInTheDocument()`
-  ),
   invalidCase(
     `expect(getByText('foo')).toHaveLength(1)`,
     `expect(getByText('foo')).toBeInTheDocument()`
@@ -290,10 +294,6 @@ const invalid = [
   ),
 
   invalidCase(
-    `expect(queryAllByText('foo')).toHaveLength(0)`,
-    `expect(queryByText('foo')).not.toBeInTheDocument()`
-  ),
-  invalidCase(
     `expect(queryAllByText('foo')).toBeNull()`,
     `expect(queryByText('foo')).not.toBeInTheDocument()`
   ),
@@ -312,14 +312,6 @@ const invalid = [
   invalidCase(
     `expect(queryAllByText('foo')) .not .toBeDefined()`,
     `expect(queryByText('foo')) .not .toBeInTheDocument()`
-  ),
-  invalidCase(
-    `let foo;
-      foo = screen.queryAllByText('foo');
-      expect(foo).toHaveLength(0);`,
-    `let foo;
-      foo = screen.queryByText('foo');
-      expect(foo).not.toBeInTheDocument();`
   ),
   invalidCase(
     `let foo;

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -30,7 +30,7 @@ function invalidCaseWithSuggestions(
   code,
   messageData,
   replaceQueryOutput,
-  replaceAssertionOutput
+  replaceMatcherOutput
 ) {
   return {
     code,
@@ -45,7 +45,7 @@ function invalidCaseWithSuggestions(
           },
           {
             desc: "Replace .toHaveLength(1) with .toBeInTheDocument()",
-            output: replaceAssertionOutput,
+            output: replaceMatcherOutput,
           },
         ],
       },

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -97,6 +97,23 @@ const valid = [
   `
   const element =  getByText('value')
   expect(element).toBeInTheDocument`,
+
+  // *AllBy queries with `.toHaveLength(1)` is valid
+  // see conclusion at https://github.com/testing-library/eslint-plugin-jest-dom/issues/171#issuecomment-895074086
+  `expect(screen.getAllByRole('foo')).toHaveLength(1)`,
+  `expect(await screen.findAllByRole('foo')).toHaveLength(1)`,
+  `expect(getAllByRole('foo')).toHaveLength(1)`,
+  `expect(wrapper.getAllByRole('foo')).toHaveLength(1)`,
+  `const foo = screen.getAllByRole('foo');
+    expect(foo).toHaveLength(1);`,
+  `const foo = getAllByRole('foo');
+    expect(foo).toHaveLength(1);`,
+  `let foo;
+    foo = getAllByRole('foo');
+    expect(foo).toHaveLength(1);`,
+  `let foo;
+    foo = screen.getAllByRole('foo');
+    expect(foo).toHaveLength(1);`,
 ];
 const invalid = [
   invalidCase(
@@ -150,51 +167,6 @@ const invalid = [
     foo = screen.getByText('foo');
     expect(foo).toBeInTheDocument();`
   ),
-  invalidCase(
-    `expect(screen.getAllByRole('foo')).toHaveLength(1)`,
-    `expect(screen.getByRole('foo')).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `expect(await screen.findAllByRole('foo')).toHaveLength(1)`,
-    `expect(await screen.findByRole('foo')).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `expect(getAllByRole('foo')).toHaveLength(1)`,
-    `expect(getByRole('foo')).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `expect(wrapper.getAllByRole('foo')).toHaveLength(1)`,
-    `expect(wrapper.getByRole('foo')).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `const foo = screen.getAllByRole('foo');
-    expect(foo).toHaveLength(1);`,
-    `const foo = screen.getByRole('foo');
-    expect(foo).toBeInTheDocument();`
-  ),
-  invalidCase(
-    `const foo = getAllByRole('foo');
-    expect(foo).toHaveLength(1);`,
-    `const foo = getByRole('foo');
-    expect(foo).toBeInTheDocument();`
-  ),
-  invalidCase(
-    `let foo;
-    foo = getAllByRole('foo');
-    expect(foo).toHaveLength(1);`,
-    `let foo;
-    foo = getByRole('foo');
-    expect(foo).toBeInTheDocument();`
-  ),
-  invalidCase(
-    `let foo;
-    foo = screen.getAllByRole('foo');
-    expect(foo).toHaveLength(1);`,
-    `let foo;
-    foo = screen.getByRole('foo');
-    expect(foo).toBeInTheDocument();`
-  ),
-
   invalidCase(
     `expect(screen.getByText('foo')).toHaveLength(1)`,
     `expect(screen.getByText('foo')).toBeInTheDocument()`
@@ -460,12 +432,6 @@ const invalid = [
     `let span;
      span = getByText('foo') as HTMLSpanElement
   expect(span).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `const things = screen.getAllByText("foo");
-  expect(things).toHaveLength(1);`,
-    `const things = screen.getByText("foo");
-  expect(things).toBeInTheDocument();`
   ),
 ];
 

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -20,7 +20,9 @@ export const meta = {
   fixable: "code",
   messages: {
     "use-document": `Prefer .toBeInTheDocument() for asserting DOM node existence`,
+    "invalid-combination-length-1": `Invalid combination of {{query}} and .toHaveLength(1). Did you mean to use {{allQuery}}?`,
   },
+  hasSuggestions: true,
 };
 
 function isAntonymMatcher(matcherNode, matcherArguments) {
@@ -96,28 +98,63 @@ export const create = (context) => {
     // only report on dom nodes which we can resolve to RTL queries.
     if (!queryNode || (!queryNode.name && !queryNode.property)) return;
 
-    // toHaveLength() is only invalid with 0 or 1
+    // *By* query with .toHaveLength(0/1) assertions are considered violations
+    //
+    // | Selector type | .toHaveLength(1)            | .toHaveLength(0)                      |
+    // | ============= | =========================== | ===================================== |
+    // | *By* query    | Did you mean to use *AllBy* | Replace with .not.toBeInTheDocument() |
+    // | *AllBy* query | Correct                     | Correct
+    //
+    // @see https://github.com/testing-library/eslint-plugin-jest-dom/issues/171
+    //
     if (matcherNode.name === "toHaveLength" && matcherArguments.length) {
       const lengthValue = getLengthValue(matcherArguments);
-      // isNotToHaveLengthZero represents .not.toHaveLength(0) which is a valid use of toHaveLength
-      const isNotToHaveLengthZero =
-        usesToHaveLengthZero(matcherNode, matcherArguments) && negatedMatcher;
+      const queryName = queryNode.name || queryNode.property.name;
 
-      // .toHaveLength(1)/.toHaveLength(0) is valid when used with *AllBy* queries
-      // meaning checking for exactly one/zero match
-      // see discussion https://github.com/testing-library/eslint-plugin-jest-dom/issues/171
-      const isValidUsageWithAllByQueries =
-        /AllBy/.test(queryNode.name) && [1, 0].includes(lengthValue);
+      const isSingleQuery =
+        queries.includes(queryName) && !/AllBy/.test(queryName);
+      const hasViolation = isSingleQuery && [1, 0].includes(lengthValue);
 
-      const isValidUseOfToHaveLength =
-        isValidUsageWithAllByQueries ||
-        isNotToHaveLengthZero ||
-        !["Literal", "Identifier"].includes(matcherArguments[0].type) ||
-        lengthValue === undefined ||
-        lengthValue > 1;
-
-      if (isValidUseOfToHaveLength) {
+      if (!hasViolation) {
         return;
+      }
+
+      // If length === 1, report violation with suggestions
+      // Otherwise fallback to default report
+      if (lengthValue === 1) {
+        const allQuery = queryName.replace("By", "AllBy");
+        return context.report({
+          node: matcherNode,
+          messageId: "invalid-combination-length-1",
+          data: {
+            query: queryName,
+            allQuery,
+          },
+          loc: matcherNode.loc,
+          suggest: [
+            {
+              desc: `Replace ${queryName} with ${allQuery}`,
+              fix(fixer) {
+                return fixer.replaceText(
+                  queryNode.property || queryNode,
+                  allQuery
+                );
+              },
+            },
+            {
+              desc: "Replace .toHaveLength(1) with .toBeInTheDocument()",
+              fix(fixer) {
+                // Remove any arguments in the matcher
+                return [
+                  ...Array.from(matcherArguments).map((argument) =>
+                    fixer.remove(argument)
+                  ),
+                  fixer.replaceText(matcherNode, "toBeInTheDocument"),
+                ];
+              },
+            },
+          ],
+        });
       }
     }
 

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -98,7 +98,7 @@ export const create = (context) => {
     // only report on dom nodes which we can resolve to RTL queries.
     if (!queryNode || (!queryNode.name && !queryNode.property)) return;
 
-    // *By* query with .toHaveLength(0/1) assertions are considered violations
+    // *By* query with .toHaveLength(0/1) matcher are considered violations
     //
     // | Selector type | .toHaveLength(1)            | .toHaveLength(0)                      |
     // | ============= | =========================== | ===================================== |

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -21,6 +21,7 @@ export const meta = {
   messages: {
     "use-document": `Prefer .toBeInTheDocument() for asserting DOM node existence`,
     "invalid-combination-length-1": `Invalid combination of {{query}} and .toHaveLength(1). Did you mean to use {{allQuery}}?`,
+    "replace-query-with-all": `Replace {{query}} with {{allQuery}}`,
   },
   hasSuggestions: true,
 };
@@ -138,7 +139,8 @@ export const create = (context) => {
           loc: matcherNode.loc,
           suggest: [
             {
-              desc: `Replace ${queryName} with ${allQuery}`,
+              messageId: "replace-query-with-all",
+              data: { query: queryName, allQuery },
               fix(fixer) {
                 return fixer.replaceText(
                   queryNode.property || queryNode,

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -43,6 +43,24 @@ function usesToHaveLengthZero(matcherNode, matcherArguments) {
   return matcherNode.name === "toHaveLength" && matcherArguments[0].value === 0;
 }
 
+/**
+ * Extract the DTL query identifier from a call expression
+ *
+ * <query>() -> <query>
+ * screen.<query>() -> <query>
+ */
+function getDTLQueryIdentifierNode(callExpressionNode) {
+  if (!callExpressionNode || callExpressionNode.type !== "CallExpression") {
+    return;
+  }
+
+  if (callExpressionNode.callee.type === "Identifier") {
+    return callExpressionNode.callee;
+  }
+
+  return callExpressionNode.callee.property;
+}
+
 export const create = (context) => {
   const alternativeMatchers =
     /^(toHaveLength|toBeDefined|toBeNull|toBe|toEqual|toBeTruthy|toBeFalsy)$/;
@@ -84,7 +102,12 @@ export const create = (context) => {
       // isNotToHaveLengthZero represents .not.toHaveLength(0) which is a valid use of toHaveLength
       const isNotToHaveLengthZero =
         usesToHaveLengthZero(matcherNode, matcherArguments) && negatedMatcher;
+
       const isValidUseOfToHaveLength =
+        // .toHaveLength(1) is valid when used with *AllBy* queries
+        // meaning checking for exactly one match
+        // see discussion https://github.com/testing-library/eslint-plugin-jest-dom/issues/171
+        (lengthValue === 1 && /AllBy/.test(queryNode.name)) ||
         isNotToHaveLengthZero ||
         !["Literal", "Identifier"].includes(matcherArguments[0].type) ||
         lengthValue === undefined ||
@@ -184,6 +207,12 @@ export const create = (context) => {
         context,
         node.object.object.arguments[0].name
       );
+
+      // Not an RTL query
+      if (!queryNode || queryNode.type !== "CallExpression") {
+        return;
+      }
+
       const matcherNode = node.property;
 
       const matcherArguments = node.parent.arguments;
@@ -201,16 +230,25 @@ export const create = (context) => {
     [`MemberExpression[object.callee.name=expect][property.name=${alternativeMatchers}][object.arguments.0.type=Identifier]`](
       node
     ) {
-      const queryNode = getAssignmentForIdentifier(
+      // Value expression being assigned to the left-hand value
+      const rightValueNode = getAssignmentForIdentifier(
         context,
         node.object.arguments[0].name
       );
+
+      // Not a DTL query
+      if (!rightValueNode || rightValueNode.type !== "CallExpression") {
+        return;
+      }
+
+      const queryIdentifierNode = getDTLQueryIdentifierNode(rightValueNode);
+
       const matcherNode = node.property;
 
       const matcherArguments = node.parent.arguments;
       check({
         negatedMatcher: false,
-        queryNode: (queryNode && queryNode.callee) || queryNode,
+        queryNode: queryIdentifierNode,
         matcherNode,
         matcherArguments,
       });
@@ -226,14 +264,17 @@ export const create = (context) => {
         return;
       }
 
-      const queryNode =
-        arg.type === "AwaitExpression" ? arg.argument.callee : arg.callee;
+      const queryIdentifierNode =
+        arg.type === "AwaitExpression"
+          ? getDTLQueryIdentifierNode(arg.argument)
+          : getDTLQueryIdentifierNode(arg);
+
       const matcherNode = node.callee.property;
       const matcherArguments = node.arguments;
 
       check({
         negatedMatcher: false,
-        queryNode,
+        queryNode: queryIdentifierNode,
         matcherNode,
         matcherArguments,
       });

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -103,11 +103,14 @@ export const create = (context) => {
       const isNotToHaveLengthZero =
         usesToHaveLengthZero(matcherNode, matcherArguments) && negatedMatcher;
 
+      // .toHaveLength(1)/.toHaveLength(0) is valid when used with *AllBy* queries
+      // meaning checking for exactly one/zero match
+      // see discussion https://github.com/testing-library/eslint-plugin-jest-dom/issues/171
+      const isValidUsageWithAllByQueries =
+        /AllBy/.test(queryNode.name) && [1, 0].includes(lengthValue);
+
       const isValidUseOfToHaveLength =
-        // .toHaveLength(1) is valid when used with *AllBy* queries
-        // meaning checking for exactly one match
-        // see discussion https://github.com/testing-library/eslint-plugin-jest-dom/issues/171
-        (lengthValue === 1 && /AllBy/.test(queryNode.name)) ||
+        isValidUsageWithAllByQueries ||
         isNotToHaveLengthZero ||
         !["Literal", "Identifier"].includes(matcherArguments[0].type) ||
         lengthValue === undefined ||


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Close #171 

**Why**:

It's valid to use `.toHaveLength(1)` with `*AllBy*` queries to check for "exactly one match".

See conclusion of discussions at https://github.com/testing-library/eslint-plugin-jest-dom/issues/171#issuecomment-895074086

<!-- How were these changes implemented? -->

**How**:

Implement the truth table as described in the link above.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
