### PR TITLE
fix(prefer-in-document): handle `toHaveLength` without any arguments and with trailing commas

### DIFF
--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -51,6 +51,10 @@ const valid = [
   expect(foo).not.toHaveLength(0)`,
   `let foo;
   expect(foo).toHaveLength(1);`,
+  `let foo;
+  expect(foo).toHaveLength()`,
+  `let foo;
+  expect(foo).toHaveLength(1, 2, 3)`,
   `expect(screen.notAQuery('foo-bar')).toHaveLength(1)`,
   `expect(screen.getAllByText('foo-bar')).toHaveLength(2)`,
   `import foo from "./foo";
@@ -99,6 +103,22 @@ const valid = [
   expect(element).toBeInTheDocument`,
 ];
 const invalid = [
+  invalidCase(
+    `expect(screen.getByText('foo')).toHaveLength()`,
+    `expect(screen.getByText('foo')).not.toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(screen.getAllByText('foo')).toHaveLength()`,
+    `expect(screen.getByText('foo')).not.toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(screen.getByRole('foo')).toHaveLength()`,
+    `expect(screen.getByRole('foo')).not.toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(screen.getAllByRole('foo')).toHaveLength()`,
+    `expect(screen.getByRole('foo')).not.toBeInTheDocument()`
+  ),
   invalidCase(
     `expect(screen.getByText('foo')).toHaveLength(1)`,
     `expect(screen.getByText('foo')).toBeInTheDocument()`

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -120,6 +120,66 @@ const invalid = [
     `expect(screen.getByRole('foo')).not.toBeInTheDocument()`
   ),
   invalidCase(
+    `expect(screen.getByRole('foo')).toHaveLength(0,2,3)`,
+    `expect(screen.getByRole('foo')).not.toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(screen.getAllByRole('foo')).toHaveLength(0,2,3,)`,
+    `expect(screen.getByRole('foo')).not.toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(screen.getByRole('foo')).toHaveLength(1,2,3)`,
+    `expect(screen.getByRole('foo')).toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(screen.getAllByRole('foo')).toHaveLength(1,2,3,)`,
+    `expect(screen.getByRole('foo')).toBeInTheDocument()`
+  ),
+  invalidCase(
+    `expect(screen.getAllByRole('foo')).toHaveLength(0//comment
+)`,
+    `expect(screen.getByRole('foo')).not.toBeInTheDocument(//comment
+)`
+  ),
+  invalidCase(
+    `expect(screen.getAllByRole('foo')).toHaveLength(1,//comment
+)`,
+    `expect(screen.getByRole('foo')).toBeInTheDocument(//comment
+)`
+  ),
+  invalidCase(
+    `expect(screen.getAllByRole('foo')).toHaveLength(0,2,3//comment
+)`,
+    `expect(screen.getByRole('foo')).not.toBeInTheDocument(//comment
+)`
+  ),
+  invalidCase(
+    `expect(screen.getAllByRole('foo')).toHaveLength(1,2,3,//comment
+)`,
+    `expect(screen.getByRole('foo')).toBeInTheDocument(//comment
+)`
+  ),
+  invalidCase(
+    `expect(screen.getAllByRole('foo')).toHaveLength(0,2,//comment
+3,4)`,
+    `expect(screen.getByRole('foo')).not.toBeInTheDocument(//comment
+)`
+  ),
+  invalidCase(
+    `expect(screen.getAllByRole('foo')).toHaveLength(1,2,//comment
+3,4,)`,
+    `expect(screen.getByRole('foo')).toBeInTheDocument(//comment
+)`
+  ),
+  invalidCase(
+    `expect(screen.getAllByRole('foo')).toHaveLength(0,2/*comment*/,3)`,
+    `expect(screen.getByRole('foo')).not.toBeInTheDocument(/*comment*/)`
+  ),
+  invalidCase(
+    `expect(screen.getAllByRole('foo')).toHaveLength(1,2,/*comment*/3,)`,
+    `expect(screen.getByRole('foo')).toBeInTheDocument(/*comment*/)`
+  ),
+  invalidCase(
     `expect(screen.getByText('foo')).toHaveLength(1)`,
     `expect(screen.getByText('foo')).toBeInTheDocument()`
   ),

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -122,6 +122,12 @@ export const create = (context) => {
 
           // Remove any arguments in the matcher
           for (const argument of Array.from(matcherArguments)) {
+            const sourceCode = context.getSourceCode();
+            const token = sourceCode.getTokenAfter(argument);
+            if (token.value === "," && token.type === "Punctuator") {
+              // Remove commas if toHaveLength had more than one argument
+              operations.push(fixer.replaceText(token, ""));
+            }
             operations.push(fixer.remove(argument));
           }
 

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -125,7 +125,7 @@ export const create = (context) => {
             const sourceCode = context.getSourceCode();
             const token = sourceCode.getTokenAfter(argument);
             if (token.value === "," && token.type === "Punctuator") {
-              // Remove commas if toHaveLength had more than one argument
+              // Remove commas if toHaveLength had more than one argument or a trailing comma
               operations.push(fixer.replaceText(token, ""));
             }
             operations.push(fixer.remove(argument));

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -40,7 +40,12 @@ function usesToBeOrToEqualWithNull(matcherNode, matcherArguments) {
 }
 
 function usesToHaveLengthZero(matcherNode, matcherArguments) {
-  return matcherNode.name === "toHaveLength" && matcherArguments[0].value === 0;
+  // matcherArguments.length === 0: toHaveLength() will cause jest matcher error
+  // matcherArguments[0].value:     toHaveLength(0, ...) means zero length
+  return (
+    matcherNode.name === "toHaveLength" &&
+    (matcherArguments.length === 0 || matcherArguments[0].value === 0)
+  );
 }
 
 export const create = (context) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
1. For toHaveLength:
  - Calling toHaveLength without any arguments causing .value on undefined object fixed. 
  - if no argument provided, toHaveLength(), it is also considered as toHaveLengthZero together with toHaveLength(0).

![image](https://user-images.githubusercontent.com/58451444/200652010-dff34dd9-351d-4254-b429-5c29ee276ea7.png)

![image](https://user-images.githubusercontent.com/58451444/200652120-b31b8124-7bb0-4181-a797-0e370667d910.png)


2. matcherArgument removal logic in eslint fixer is updated to remove the commas also, if there were multiple args in the matcher.

![image](https://user-images.githubusercontent.com/58451444/200652544-3f0f209a-284c-41d0-bb57-f51e7369e7fc.png)

![image](https://user-images.githubusercontent.com/58451444/200652803-9b23b937-9414-4b70-b4f2-27c6e2f512dc.png)

![image](https://user-images.githubusercontent.com/58451444/200653147-b3993108-eabf-450f-afa6-6e532d7aa6be.png)


<!-- Why are these changes necessary? -->

**Why**:
1. toHaveLength method on expect is causing eslint to crash since no argument logic isn't handled properly in the prefer-in-document rule. If eslint is always watching and linting live, this issue is quite annoying.

Eslint plugin crush stack trace in VSCode:

![image](https://user-images.githubusercontent.com/58451444/200651481-a7e71370-8cdf-482e-bb90-20e2649b4db4.png)


Even after handling calling toHaveLength without any arguments, it won't work since toHaveLength expected argument is [required](https://github.com/facebook/jest/blob/main/packages/expect/src/types.ts#L270). Thus, toHaveLength without any arguments considered as toHaveLength zero.

2.` toHaveLength(0)` and `toHaveLength(1)` on a RTL query replaced to proper `toBeInTheDocument`'s. Logic is already applied to work with multiple arguments but, if there were multiple arguments after 0 or 1, commas aren't removed. 

![image](https://user-images.githubusercontent.com/58451444/200651077-26ea7c27-1c9e-425a-80d5-d1763fe6af51.png)

![image](https://user-images.githubusercontent.com/58451444/200651086-bdb23981-30ce-454e-889a-7ea46b4e4d7a.png)



<!-- How were these changes implemented? -->

**How**:

1. to fix eslint crashing issue (.value on undefined in matcherArguments[0].value): empty arg array is handled properly. 

```(matcherArguments.length === 0 || matcherArguments[0].value === 0)```

2. while removing arguments following lines added to remove commas also:

```
const sourceCode = context.getSourceCode();
const token = sourceCode.getTokenAfter(argument);
if (token.value === "," && token.type === "Punctuator") {
  // Remove commas if toHaveLength had more than one argument or a trailing comma
  operations.push(fixer.replaceText(token, ""));
}
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
