### PR TITLE
chore: fix badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ MIT
 <!-- prettier-ignore-start -->
 [npm]: https://www.npmjs.com
 [node]: https://nodejs.org
-[build-badge]: https://img.shields.io/github/workflow/status/testing-library/eslint-plugin-jest-dom/validate?logo=github&style=flat-square
+[build-badge]: https://img.shields.io/github/actions/workflow/status/testing-library/eslint-plugin-jest-dom/validate.yml?logo=github&style=flat-square
 [build]: https://github.com/testing-library/eslint-plugin-jest-dom/actions?query=workflow%3Avalidate
 [coverage-badge]: https://img.shields.io/codecov/c/github/testing-library/eslint-plugin-jest-dom.svg?style=flat-square
 [coverage]: https://codecov.io/github/testing-library/eslint-plugin-jest-dom
@@ -196,6 +196,7 @@ MIT
 [coc]: https://github.com/testing-library/eslint-plugin-jest-dom/blob/main/other/CODE_OF_CONDUCT.md
 [emojis]: https://github.com/all-contributors/all-contributors#emoji-key
 [all-contributors]: https://github.com/all-contributors/all-contributors
+[all-contributors-badge]: https://img.shields.io/github/all-contributors/testing-library/eslint-plugin-jest-dom
 [bugs]: https://github.com/testing-library/eslint-plugin-jest-dom/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Acreated-desc+label%3Abug
 [requests]: https://github.com/testing-library/eslint-plugin-jest-dom/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3Aenhancement
 [good-first-issue]: https://github.com/testing-library/eslint-plugin-jest-dom/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3Aenhancement+label%3A%22good+first+issue%22


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What happened**:

Some badges on the readme are broken.

**How to fix**:

- The GitHub Actions new badge URL: https://github.com/badges/shields/issues/8671
- The all-contributions badge can be found at https://shields.io

**Checklist**:

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged
