### PR TITLE
fix(prefer-to-have-style): do not offer invalid autofix for computed accessors

### DIFF
--- a/src/__tests__/lib/rules/prefer-to-have-style.js
+++ b/src/__tests__/lib/rules/prefer-to-have-style.js
@@ -167,5 +167,15 @@ ruleTester.run("prefer-to-have-style", rule, {
       code: `expect(element.style[0]).toBe(/RegExp/);`,
       errors,
     },
+    {
+      code: `expect(imageElement.style[computed]).toBe(\`inset 0px 0px 0px 400px \${c}\`)`,
+      errors,
+      output: null,
+    },
+    {
+      code: `expect(imageElement.style[computed]).not.toBe(\`inset 0px 0px 0px 400px \${c}\`)`,
+      errors,
+      output: null,
+    },
   ],
 });

--- a/src/rules/prefer-to-have-style.js
+++ b/src/rules/prefer-to-have-style.js
@@ -169,7 +169,8 @@ export const create = (context) => {
 
       if (
         typeof styleValue.value !== "number" &&
-        !(styleValue.value instanceof RegExp)
+        !(styleValue.value instanceof RegExp) &&
+        styleName.type !== 'Identifier'
       ) {
         fix = (fixer) => {
           return [
@@ -208,7 +209,7 @@ export const create = (context) => {
 
       let fix = null;
 
-      if (typeof styleName.value !== "number") {
+      if (typeof styleName.value !== "number" && styleName.type !== 'Identifier') {
         fix = (fixer) => {
           return [
             fixer.removeRange([

--- a/src/rules/prefer-to-have-style.js
+++ b/src/rules/prefer-to-have-style.js
@@ -170,7 +170,7 @@ export const create = (context) => {
       if (
         typeof styleValue.value !== "number" &&
         !(styleValue.value instanceof RegExp) &&
-        styleName.type !== 'Identifier'
+        styleName.type !== "Identifier"
       ) {
         fix = (fixer) => {
           return [
@@ -209,7 +209,10 @@ export const create = (context) => {
 
       let fix = null;
 
-      if (typeof styleName.value !== "number" && styleName.type !== 'Identifier') {
+      if (
+        typeof styleName.value !== "number" &&
+        styleName.type !== "Identifier"
+      ) {
         fix = (fixer) => {
           return [
             fixer.removeRange([


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Changes `prefer-to-have-style` to not give an autofix if a variable is being used to access `style`.

<!-- Why are these changes necessary? -->

**Why**:

Because it generates an invalid autofixer.

Note that we could probably do at least a suggestion (or two), but at this point I'm not too sure of the semantics and currently this is creating invalid code - if someone wants to do a followup PR that improves this rule, I'd be happy to review it.

<!-- How were these changes implemented? -->

**How**:

By not setting `fix` if the node is an `Identifier`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Resolves #265
Resolves #286

(note I've purposely not formatted my code to test a theory)
