### PR TITLE
fix(prefer-in-document): false positive on .toHaveLength(1) matcher with *AllBy* query

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,21 +96,22 @@ module.exports = {
 
 💼 Configurations enabled in.\
 ✅ Set in the `recommended` configuration.\
-🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
+🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
-| Name                                                                     | Description                                                           | 💼 | 🔧 |
-| :----------------------------------------------------------------------- | :-------------------------------------------------------------------- | :- | :- |
-| [prefer-checked](docs/rules/prefer-checked.md)                           | prefer toBeChecked over checking attributes                           | ✅  | 🔧 |
-| [prefer-empty](docs/rules/prefer-empty.md)                               | Prefer toBeEmpty over checking innerHTML                              | ✅  | 🔧 |
-| [prefer-enabled-disabled](docs/rules/prefer-enabled-disabled.md)         | prefer toBeDisabled or toBeEnabled over checking attributes           | ✅  | 🔧 |
-| [prefer-focus](docs/rules/prefer-focus.md)                               | prefer toHaveFocus over checking document.activeElement               | ✅  | 🔧 |
-| [prefer-in-document](docs/rules/prefer-in-document.md)                   | Prefer .toBeInTheDocument() for asserting the existence of a DOM node | ✅  | 🔧 |
-| [prefer-required](docs/rules/prefer-required.md)                         | prefer toBeRequired over checking properties                          | ✅  | 🔧 |
-| [prefer-to-have-attribute](docs/rules/prefer-to-have-attribute.md)       | prefer toHaveAttribute over checking  getAttribute/hasAttribute       | ✅  | 🔧 |
-| [prefer-to-have-class](docs/rules/prefer-to-have-class.md)               | prefer toHaveClass over checking element className                    | ✅  | 🔧 |
-| [prefer-to-have-style](docs/rules/prefer-to-have-style.md)               | prefer toHaveStyle over checking element style                        | ✅  | 🔧 |
-| [prefer-to-have-text-content](docs/rules/prefer-to-have-text-content.md) | Prefer toHaveTextContent over checking element.textContent            | ✅  | 🔧 |
-| [prefer-to-have-value](docs/rules/prefer-to-have-value.md)               | prefer toHaveValue over checking element.value                        | ✅  | 🔧 |
+| Name                                                                     | Description                                                           | 💼 | 🔧 | 💡 |
+| :----------------------------------------------------------------------- | :-------------------------------------------------------------------- | :- | :- | :- |
+| [prefer-checked](docs/rules/prefer-checked.md)                           | prefer toBeChecked over checking attributes                           | ✅  | 🔧 |    |
+| [prefer-empty](docs/rules/prefer-empty.md)                               | Prefer toBeEmpty over checking innerHTML                              | ✅  | 🔧 |    |
+| [prefer-enabled-disabled](docs/rules/prefer-enabled-disabled.md)         | prefer toBeDisabled or toBeEnabled over checking attributes           | ✅  | 🔧 |    |
+| [prefer-focus](docs/rules/prefer-focus.md)                               | prefer toHaveFocus over checking document.activeElement               | ✅  | 🔧 |    |
+| [prefer-in-document](docs/rules/prefer-in-document.md)                   | Prefer .toBeInTheDocument() for asserting the existence of a DOM node | ✅  | 🔧 | 💡 |
+| [prefer-required](docs/rules/prefer-required.md)                         | prefer toBeRequired over checking properties                          | ✅  | 🔧 |    |
+| [prefer-to-have-attribute](docs/rules/prefer-to-have-attribute.md)       | prefer toHaveAttribute over checking  getAttribute/hasAttribute       | ✅  | 🔧 |    |
+| [prefer-to-have-class](docs/rules/prefer-to-have-class.md)               | prefer toHaveClass over checking element className                    | ✅  | 🔧 |    |
+| [prefer-to-have-style](docs/rules/prefer-to-have-style.md)               | prefer toHaveStyle over checking element style                        | ✅  | 🔧 |    |
+| [prefer-to-have-text-content](docs/rules/prefer-to-have-text-content.md) | Prefer toHaveTextContent over checking element.textContent            | ✅  | 🔧 |    |
+| [prefer-to-have-value](docs/rules/prefer-to-have-value.md)               | prefer toHaveValue over checking element.value                        | ✅  | 🔧 |    |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/prefer-in-document.md
+++ b/docs/rules/prefer-in-document.md
@@ -11,6 +11,7 @@
 This rule enforces checking existance of DOM nodes using `.toBeInTheDocument()`.
 The rule prefers that matcher over various existance checks such as `.toHaveLength(1)`, `.not.toBeNull()` and
 similar.
+However it's considered OK to use `.toHaveLength(value)` matcher with `*AllBy*` queries.
 
 Examples of **incorrect** code for this rule:
 
@@ -46,7 +47,7 @@ expect(screen.getByText("foo").length).toBe(1);
 expect(screen.queryByText("foo")).toBeInTheDocument();
 expect(await screen.findByText("foo")).toBeInTheDocument();
 expect(queryByText("foo")).toBeInTheDocument();
-expect(wrapper.queryAllByTestId("foo")).toBeInTheDocument();
+expect(wrapper.queryAllByTestId("foo")).toHaveLength(1);
 expect(screen.getAllByLabel("foo-bar")).toHaveLength(2);
 expect(notAQuery("foo-bar")).toHaveLength(1);
 

--- a/docs/rules/prefer-in-document.md
+++ b/docs/rules/prefer-in-document.md
@@ -2,7 +2,7 @@
 
 💼 This rule is enabled in the ✅ `recommended` config.
 
-🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+🔧💡 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 <!-- end auto-generated rule header -->
 

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -188,18 +188,6 @@ const invalid = [
     `expect(screen.getByRole('foo')).toBeInTheDocument()`
   ),
   invalidCase(
-    `expect(screen.getAllByRole('foo')).toHaveLength(0//comment
-)`,
-    `expect(screen.getByRole('foo')).not.toBeInTheDocument(//comment
-)`
-  ),
-  invalidCase(
-    `expect(screen.getAllByRole('foo')).toHaveLength(1,//comment
-)`,
-    `expect(screen.getByRole('foo')).toBeInTheDocument(//comment
-)`
-  ),
-  invalidCase(
     `expect(screen.getAllByRole('foo')).toHaveLength(0,2,3//comment
 )`,
     `expect(screen.getByRole('foo')).not.toBeInTheDocument(//comment

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -30,7 +30,7 @@ function invalidCaseWithSuggestions(
   code,
   messageData,
   replaceQueryOutput,
-  replaceAssertionOutput
+  replaceMatcherOutput
 ) {
   return {
     code,
@@ -45,7 +45,7 @@ function invalidCaseWithSuggestions(
           },
           {
             desc: "Replace .toHaveLength(1) with .toBeInTheDocument()",
-            output: replaceAssertionOutput,
+            output: replaceMatcherOutput,
           },
         ],
       },

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -101,6 +101,23 @@ const valid = [
   `
   const element =  getByText('value')
   expect(element).toBeInTheDocument`,
+
+  // *AllBy queries with `.toHaveLength(1)` is valid
+  // see conclusion at https://github.com/testing-library/eslint-plugin-jest-dom/issues/171#issuecomment-895074086
+  `expect(screen.getAllByRole('foo')).toHaveLength(1)`,
+  `expect(await screen.findAllByRole('foo')).toHaveLength(1)`,
+  `expect(getAllByRole('foo')).toHaveLength(1)`,
+  `expect(wrapper.getAllByRole('foo')).toHaveLength(1)`,
+  `const foo = screen.getAllByRole('foo');
+    expect(foo).toHaveLength(1);`,
+  `const foo = getAllByRole('foo');
+    expect(foo).toHaveLength(1);`,
+  `let foo;
+    foo = getAllByRole('foo');
+    expect(foo).toHaveLength(1);`,
+  `let foo;
+    foo = screen.getAllByRole('foo');
+    expect(foo).toHaveLength(1);`,
 ];
 const invalid = [
   invalidCase(
@@ -230,51 +247,6 @@ const invalid = [
     foo = screen.getByText('foo');
     expect(foo).toBeInTheDocument();`
   ),
-  invalidCase(
-    `expect(screen.getAllByRole('foo')).toHaveLength(1)`,
-    `expect(screen.getByRole('foo')).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `expect(await screen.findAllByRole('foo')).toHaveLength(1)`,
-    `expect(await screen.findByRole('foo')).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `expect(getAllByRole('foo')).toHaveLength(1)`,
-    `expect(getByRole('foo')).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `expect(wrapper.getAllByRole('foo')).toHaveLength(1)`,
-    `expect(wrapper.getByRole('foo')).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `const foo = screen.getAllByRole('foo');
-    expect(foo).toHaveLength(1);`,
-    `const foo = screen.getByRole('foo');
-    expect(foo).toBeInTheDocument();`
-  ),
-  invalidCase(
-    `const foo = getAllByRole('foo');
-    expect(foo).toHaveLength(1);`,
-    `const foo = getByRole('foo');
-    expect(foo).toBeInTheDocument();`
-  ),
-  invalidCase(
-    `let foo;
-    foo = getAllByRole('foo');
-    expect(foo).toHaveLength(1);`,
-    `let foo;
-    foo = getByRole('foo');
-    expect(foo).toBeInTheDocument();`
-  ),
-  invalidCase(
-    `let foo;
-    foo = screen.getAllByRole('foo');
-    expect(foo).toHaveLength(1);`,
-    `let foo;
-    foo = screen.getByRole('foo');
-    expect(foo).toBeInTheDocument();`
-  ),
-
   invalidCase(
     `expect(screen.getByText('foo')).toHaveLength(1)`,
     `expect(screen.getByText('foo')).toBeInTheDocument()`
@@ -540,12 +512,6 @@ const invalid = [
     `let span;
      span = getByText('foo') as HTMLSpanElement
   expect(span).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `const things = screen.getAllByText("foo");
-  expect(things).toHaveLength(1);`,
-    `const things = screen.getByText("foo");
-  expect(things).toBeInTheDocument();`
   ),
 ];
 

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -102,7 +102,7 @@ const valid = [
   const element =  getByText('value')
   expect(element).toBeInTheDocument`,
 
-  // *AllBy queries with `.toHaveLength(1)` is valid
+  // *AllBy* queries with `.toHaveLength(1)` is valid
   // see conclusion at https://github.com/testing-library/eslint-plugin-jest-dom/issues/171#issuecomment-895074086
   `expect(screen.getAllByRole('foo')).toHaveLength(1)`,
   `expect(await screen.findAllByRole('foo')).toHaveLength(1)`,
@@ -118,6 +118,14 @@ const valid = [
   `let foo;
     foo = screen.getAllByRole('foo');
     expect(foo).toHaveLength(1);`,
+
+  // *AllBy* queries with `.toHaveLength(0)` is valid
+  // see conclusion at https://github.com/testing-library/eslint-plugin-jest-dom/issues/171#issuecomment-895074086
+  `expect(screen.queryAllByTestId("foo")).toHaveLength(0)`,
+  `expect(queryAllByText('foo')).toHaveLength(0)`,
+  `let foo;
+    foo = screen.queryAllByText('foo');
+    expect(foo).toHaveLength(0);`,
 ];
 const invalid = [
   invalidCase(
@@ -207,10 +215,6 @@ const invalid = [
      expect(screen.getByText('foo')).toBeInTheDocument()`
   ),
 
-  invalidCase(
-    `expect(screen.queryAllByTestId("foo")).toHaveLength(0)`,
-    `expect(screen.queryByTestId("foo")).not.toBeInTheDocument()`
-  ),
   invalidCase(
     `expect(getByText('foo')).toHaveLength(1)`,
     `expect(getByText('foo')).toBeInTheDocument()`
@@ -370,10 +374,6 @@ const invalid = [
   ),
 
   invalidCase(
-    `expect(queryAllByText('foo')).toHaveLength(0)`,
-    `expect(queryByText('foo')).not.toBeInTheDocument()`
-  ),
-  invalidCase(
     `expect(queryAllByText('foo')).toBeNull()`,
     `expect(queryByText('foo')).not.toBeInTheDocument()`
   ),
@@ -392,14 +392,6 @@ const invalid = [
   invalidCase(
     `expect(queryAllByText('foo')) .not .toBeDefined()`,
     `expect(queryByText('foo')) .not .toBeInTheDocument()`
-  ),
-  invalidCase(
-    `let foo;
-      foo = screen.queryAllByText('foo');
-      expect(foo).toHaveLength(0);`,
-    `let foo;
-      foo = screen.queryByText('foo');
-      expect(foo).not.toBeInTheDocument();`
   ),
   invalidCase(
     `let foo;

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -146,6 +146,16 @@ const valid = [
     foo = screen.getAllByRole('foo');
     expect(foo).toHaveLength(1);`,
 
+  `expect(screen.getAllByRole('foo')).toHaveLength(1,//comment
+  )`,
+  `const foo = screen.getAllByRole('foo');
+    expect(foo).toHaveLength(1,//comment
+    );`,
+  `let foo;
+    foo = screen.getAllByRole('foo');
+    expect(foo).toHaveLength(1,//comment
+    );`,
+
   // *AllBy* queries with `.toHaveLength(0)` is valid
   // see conclusion at https://github.com/testing-library/eslint-plugin-jest-dom/issues/171#issuecomment-895074086
   `expect(screen.queryAllByTestId("foo")).toHaveLength(0)`,
@@ -153,6 +163,13 @@ const valid = [
   `let foo;
     foo = screen.queryAllByText('foo');
     expect(foo).toHaveLength(0);`,
+
+  `expect(screen.getAllByRole('foo')).toHaveLength(0//comment
+    )`,
+  `let foo;
+    foo = screen.getAllByRole('foo');
+    expect(foo).toHaveLength(0//comment
+    );`,
 ];
 const invalid = [
   invalidCase(

--- a/src/__tests__/lib/rules/prefer-in-document.js
+++ b/src/__tests__/lib/rules/prefer-in-document.js
@@ -26,6 +26,33 @@ function invalidCase(code, output) {
   };
 }
 
+function invalidCaseWithSuggestions(
+  code,
+  messageData,
+  replaceQueryOutput,
+  replaceAssertionOutput
+) {
+  return {
+    code,
+    errors: [
+      {
+        messageId: "invalid-combination-length-1",
+        data: messageData,
+        suggestions: [
+          {
+            desc: `Replace ${messageData.query} with ${messageData.allQuery}`,
+            output: replaceQueryOutput,
+          },
+          {
+            desc: "Replace .toHaveLength(1) with .toBeInTheDocument()",
+            output: replaceAssertionOutput,
+          },
+        ],
+      },
+    ],
+  };
+}
+
 const valid = [
   "expect().toBe(true)",
   ...["getByText", "getByRole"].map((q) => [
@@ -204,92 +231,103 @@ const invalid = [
     `expect(screen.getAllByRole('foo')).toHaveLength(1,2,/*comment*/3,)`,
     `expect(screen.getByRole('foo')).toBeInTheDocument(/*comment*/)`
   ),
-  invalidCase(
+  // Report invalid combination of *By* query with .toHaveLength(1) assertion
+  // and suggest fixes by:
+  // - Replacing *By* with *AllBy* query
+  // - Replacing .toHaveLength(1) with .toBeInTheDocument() assertion
+  invalidCaseWithSuggestions(
     `expect(screen.getByText('foo')).toHaveLength(1)`,
+    {
+      query: "getByText",
+      allQuery: "getAllByText",
+    },
+    `expect(screen.getAllByText('foo')).toHaveLength(1)`,
     `expect(screen.getByText('foo')).toBeInTheDocument()`
   ),
-  invalidCase(
+  invalidCaseWithSuggestions(
     `const NUM_BUTTONS=1;
      expect(screen.getByText('foo')).toHaveLength(NUM_BUTTONS)`,
+    {
+      query: "getByText",
+      allQuery: "getAllByText",
+    },
+    `const NUM_BUTTONS=1;
+     expect(screen.getAllByText('foo')).toHaveLength(NUM_BUTTONS)`,
     `const NUM_BUTTONS=1;
      expect(screen.getByText('foo')).toBeInTheDocument()`
   ),
 
-  invalidCase(
+  invalidCaseWithSuggestions(
     `expect(getByText('foo')).toHaveLength(1)`,
+    {
+      query: "getByText",
+      allQuery: "getAllByText",
+    },
+    `expect(getAllByText('foo')).toHaveLength(1)`,
     `expect(getByText('foo')).toBeInTheDocument()`
   ),
-  invalidCase(
+  invalidCaseWithSuggestions(
     `expect(wrapper.getByText('foo')).toHaveLength(1)`,
+    {
+      query: "getByText",
+      allQuery: "getAllByText",
+    },
+    `expect(wrapper.getAllByText('foo')).toHaveLength(1)`,
     `expect(wrapper.getByText('foo')).toBeInTheDocument()`
   ),
-  invalidCase(
+  invalidCaseWithSuggestions(
     `const foo = screen.getByText('foo');
+    expect(foo).toHaveLength(1);`,
+    {
+      query: "getByText",
+      allQuery: "getAllByText",
+    },
+    `const foo = screen.getAllByText('foo');
     expect(foo).toHaveLength(1);`,
     `const foo = screen.getByText('foo');
     expect(foo).toBeInTheDocument();`
   ),
-  invalidCase(
+  invalidCaseWithSuggestions(
     `const foo = getByText('foo');
+    expect(foo).toHaveLength(1);`,
+    {
+      query: "getByText",
+      allQuery: "getAllByText",
+    },
+    `const foo = getAllByText('foo');
     expect(foo).toHaveLength(1);`,
     `const foo = getByText('foo');
     expect(foo).toBeInTheDocument();`
   ),
-  invalidCase(
+  invalidCaseWithSuggestions(
     `let foo;
     foo = getByText('foo');
     expect(foo).toHaveLength(1);`,
+    {
+      query: "getByText",
+      allQuery: "getAllByText",
+    },
+    `let foo;
+    foo = getAllByText('foo');
+    expect(foo).toHaveLength(1);`,
     `let foo;
     foo = getByText('foo');
     expect(foo).toBeInTheDocument();`
   ),
-  invalidCase(
+  invalidCaseWithSuggestions(
     `let foo;
     foo = screen.getByText('foo');
+    expect(foo).toHaveLength(1);`,
+    {
+      query: "getByText",
+      allQuery: "getAllByText",
+    },
+    `let foo;
+    foo = screen.getAllByText('foo');
     expect(foo).toHaveLength(1);`,
     `let foo;
     foo = screen.getByText('foo');
     expect(foo).toBeInTheDocument();`
-  ),
-  invalidCase(
-    `expect(screen.getByText('foo')).toHaveLength(1)`,
-    `expect(screen.getByText('foo')).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `expect(getByText('foo')).toHaveLength(1)`,
-    `expect(getByText('foo')).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `expect(wrapper.getByText('foo')).toHaveLength(1)`,
-    `expect(wrapper.getByText('foo')).toBeInTheDocument()`
-  ),
-  invalidCase(
-    `const foo = screen.getByText('foo');
-  expect(foo).toHaveLength(1);`,
-    `const foo = screen.getByText('foo');
-  expect(foo).toBeInTheDocument();`
-  ),
-  invalidCase(
-    `const foo = getByText('foo');
-  expect(foo).toHaveLength(1);`,
-    `const foo = getByText('foo');
-  expect(foo).toBeInTheDocument();`
-  ),
-  invalidCase(
-    `let foo;
-  foo = getByText('foo');
-  expect(foo).toHaveLength(1);`,
-    `let foo;
-  foo = getByText('foo');
-  expect(foo).toBeInTheDocument();`
-  ),
-  invalidCase(
-    `let foo;
-  foo = screen.getByText('foo');
-  expect(foo).toHaveLength(1);`,
-    `let foo;
-  foo = screen.getByText('foo');
-  expect(foo).toBeInTheDocument();`
   ),
 
   // Invalid cases that applies to queryBy* and queryAllBy*

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -20,8 +20,8 @@ export const meta = {
   fixable: "code",
   messages: {
     "use-document": `Prefer .toBeInTheDocument() for asserting DOM node existence`,
-    "invalid-combination-length-1": `Invalid combination of {{query}} and .toHaveLength(1). Did you mean to use {{allQuery}}?`,
-    "replace-query-with-all": `Replace {{query}} with {{allQuery}}`,
+    "invalid-combination-length-1": `Invalid combination of {{ query }} and .toHaveLength(1). Did you mean to use {{ allQuery }}?`,
+    "replace-query-with-all": `Replace {{ query }} with {{ allQuery }}`,
   },
   hasSuggestions: true,
 };
@@ -59,7 +59,7 @@ function usesToHaveLengthZero(matcherNode, matcherArguments) {
  */
 function getDTLQueryIdentifierNode(callExpressionNode) {
   if (!callExpressionNode || callExpressionNode.type !== "CallExpression") {
-    return;
+    return null;
   }
 
   if (callExpressionNode.callee.type === "Identifier") {
@@ -272,7 +272,7 @@ export const create = (context) => {
       const expect = node.object.object;
       check({
         negatedMatcher: true,
-        queryNode: (queryNode && queryNode.callee) || queryNode,
+        queryNode: queryNode.callee,
         matcherNode,
         matcherArguments,
         expect,

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -103,7 +103,7 @@ export const create = (context) => {
     // only report on dom nodes which we can resolve to RTL queries.
     if (!queryNode || (!queryNode.name && !queryNode.property)) return;
 
-    // *By* query with .toHaveLength(0/1) assertions are considered violations
+    // *By* query with .toHaveLength(0/1) matcher are considered violations
     //
     // | Selector type | .toHaveLength(1)            | .toHaveLength(0)                      |
     // | ============= | =========================== | ===================================== |

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -48,6 +48,24 @@ function usesToHaveLengthZero(matcherNode, matcherArguments) {
   );
 }
 
+/**
+ * Extract the DTL query identifier from a call expression
+ *
+ * <query>() -> <query>
+ * screen.<query>() -> <query>
+ */
+function getDTLQueryIdentifierNode(callExpressionNode) {
+  if (!callExpressionNode || callExpressionNode.type !== "CallExpression") {
+    return;
+  }
+
+  if (callExpressionNode.callee.type === "Identifier") {
+    return callExpressionNode.callee;
+  }
+
+  return callExpressionNode.callee.property;
+}
+
 export const create = (context) => {
   const alternativeMatchers =
     /^(toHaveLength|toBeDefined|toBeNull|toBe|toEqual|toBeTruthy|toBeFalsy)$/;
@@ -89,7 +107,12 @@ export const create = (context) => {
       // isNotToHaveLengthZero represents .not.toHaveLength(0) which is a valid use of toHaveLength
       const isNotToHaveLengthZero =
         usesToHaveLengthZero(matcherNode, matcherArguments) && negatedMatcher;
+
       const isValidUseOfToHaveLength =
+        // .toHaveLength(1) is valid when used with *AllBy* queries
+        // meaning checking for exactly one match
+        // see discussion https://github.com/testing-library/eslint-plugin-jest-dom/issues/171
+        (lengthValue === 1 && /AllBy/.test(queryNode.name)) ||
         isNotToHaveLengthZero ||
         !["Literal", "Identifier"].includes(matcherArguments[0].type) ||
         lengthValue === undefined ||
@@ -195,6 +218,12 @@ export const create = (context) => {
         context,
         node.object.object.arguments[0].name
       );
+
+      // Not an RTL query
+      if (!queryNode || queryNode.type !== "CallExpression") {
+        return;
+      }
+
       const matcherNode = node.property;
 
       const matcherArguments = node.parent.arguments;
@@ -212,16 +241,25 @@ export const create = (context) => {
     [`MemberExpression[object.callee.name=expect][property.name=${alternativeMatchers}][object.arguments.0.type=Identifier]`](
       node
     ) {
-      const queryNode = getAssignmentForIdentifier(
+      // Value expression being assigned to the left-hand value
+      const rightValueNode = getAssignmentForIdentifier(
         context,
         node.object.arguments[0].name
       );
+
+      // Not a DTL query
+      if (!rightValueNode || rightValueNode.type !== "CallExpression") {
+        return;
+      }
+
+      const queryIdentifierNode = getDTLQueryIdentifierNode(rightValueNode);
+
       const matcherNode = node.property;
 
       const matcherArguments = node.parent.arguments;
       check({
         negatedMatcher: false,
-        queryNode: (queryNode && queryNode.callee) || queryNode,
+        queryNode: queryIdentifierNode,
         matcherNode,
         matcherArguments,
       });
@@ -237,14 +275,17 @@ export const create = (context) => {
         return;
       }
 
-      const queryNode =
-        arg.type === "AwaitExpression" ? arg.argument.callee : arg.callee;
+      const queryIdentifierNode =
+        arg.type === "AwaitExpression"
+          ? getDTLQueryIdentifierNode(arg.argument)
+          : getDTLQueryIdentifierNode(arg);
+
       const matcherNode = node.callee.property;
       const matcherArguments = node.arguments;
 
       check({
         negatedMatcher: false,
-        queryNode,
+        queryNode: queryIdentifierNode,
         matcherNode,
         matcherArguments,
       });

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -21,6 +21,7 @@ export const meta = {
   messages: {
     "use-document": `Prefer .toBeInTheDocument() for asserting DOM node existence`,
     "invalid-combination-length-1": `Invalid combination of {{query}} and .toHaveLength(1). Did you mean to use {{allQuery}}?`,
+    "replace-query-with-all": `Replace {{query}} with {{allQuery}}`,
   },
   hasSuggestions: true,
 };
@@ -138,7 +139,8 @@ export const create = (context) => {
           loc: matcherNode.loc,
           suggest: [
             {
-              desc: `Replace ${queryName} with ${allQuery}`,
+              messageId: "replace-query-with-all",
+              data: { query: queryName, allQuery },
               fix(fixer) {
                 return fixer.replaceText(
                   queryNode.property || queryNode,

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -113,7 +113,7 @@ export const create = (context) => {
     //
     // @see https://github.com/testing-library/eslint-plugin-jest-dom/issues/171
     //
-    if (matcherNode.name === "toHaveLength" && matcherArguments.length) {
+    if (matcherNode.name === "toHaveLength" && matcherArguments.length === 1) {
       const lengthValue = getLengthValue(matcherArguments);
       const queryName = queryNode.name || queryNode.property.name;
 
@@ -124,7 +124,6 @@ export const create = (context) => {
       if (!hasViolation) {
         return;
       }
-
       // If length === 1, report violation with suggestions
       // Otherwise fallback to default report
       if (lengthValue === 1) {

--- a/src/rules/prefer-in-document.js
+++ b/src/rules/prefer-in-document.js
@@ -108,11 +108,14 @@ export const create = (context) => {
       const isNotToHaveLengthZero =
         usesToHaveLengthZero(matcherNode, matcherArguments) && negatedMatcher;
 
+      // .toHaveLength(1)/.toHaveLength(0) is valid when used with *AllBy* queries
+      // meaning checking for exactly one/zero match
+      // see discussion https://github.com/testing-library/eslint-plugin-jest-dom/issues/171
+      const isValidUsageWithAllByQueries =
+        /AllBy/.test(queryNode.name) && [1, 0].includes(lengthValue);
+
       const isValidUseOfToHaveLength =
-        // .toHaveLength(1) is valid when used with *AllBy* queries
-        // meaning checking for exactly one match
-        // see discussion https://github.com/testing-library/eslint-plugin-jest-dom/issues/171
-        (lengthValue === 1 && /AllBy/.test(queryNode.name)) ||
+        isValidUsageWithAllByQueries ||
         isNotToHaveLengthZero ||
         !["Literal", "Identifier"].includes(matcherArguments[0].type) ||
         lengthValue === undefined ||


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->
Closes https://github.com/testing-library/eslint-plugin-jest-dom/issues/171
Closes #273

**Why**:

<!-- How were these changes implemented? -->
It's valid to use .toHaveLength(1) with *AllBy* queries to check for "exactly one match".

See conclusion of discussions at https://github.com/testing-library/eslint-plugin-jest-dom/issues/171#issuecomment-895074086

**How**:

<!-- Have you done all of these things?  -->
Implement the truth table as described in the link above.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
I basically just re-pushed #273 and made a few changes to the test suite.