### PR TITLE
feat: add should-be-fine support for flat configs

### DIFF
--- a/.eslint-doc-generatorrc.js
+++ b/.eslint-doc-generatorrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint-doc-generator').GenerateOptions} */
+const config = {
+  ignoreConfig: [
+    'all',
+    'flat/all',
+    'flat/recommended',
+  ],
+};
+
+module.exports = config;

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ This library has a required `peerDependencies` listing for [`ESLint`](https://es
 
 ## Usage
 
+> [!NOTE]
+>
+> `eslint.config.js` is supported, though most of the plugin documentation still
+> currently uses `.eslintrc` syntax; compatible versions of configs are available
+> prefixed with `flat/` and may be subject to small breaking changes while ESLint
+> v9 is being finalized.
+>
+> Refer to the
+> [ESLint documentation on the new configuration file format](https://eslint.org/docs/latest/use/configure/configuration-files-new)
+> for more.
+
 Add `jest-dom` to the plugins section of your `.eslintrc.js` configuration file.
 You can omit the `eslint-plugin-` prefix:
 
@@ -78,8 +89,7 @@ This plugin exports a recommended configuration that enforces good `jest-dom`
 practices _(you can find more info about enabled rules in
 [Supported Rules section](#supported-rules))_.
 
-To enable this configuration use the `extends` property in your `.eslintrc.js`
-config file:
+To enable this configuration with `.eslintrc`, use the `extends` property:
 
 ```javascript
 module.exports = {
@@ -88,6 +98,20 @@ module.exports = {
     // your configuration
   },
 };
+```
+
+To enable this configuration with `eslint.config.js`, use
+`jestDom.configs['flat/recommended']`:
+
+```javascript
+module.exports = [
+  {
+    files: [
+      /* glob matching your test files */
+    ],
+    ...require("eslint-plugin-jest-dom").configs["flat/recommended"],
+  },
+];
 ```
 
 ## Supported Rules

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "kcd-scripts build",
     "pregenerate-readme-table": "npm run build",
-    "generate-readme-table": "eslint-doc-generator --ignore-config all",
+    "generate-readme-table": "eslint-doc-generator",
     "lint": "kcd-scripts lint",
     "lint:generate-readme-table": "npm run generate-readme-table -- --check",
     "setup": "npm install && npm run validate -s",

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,7 +1,7 @@
 import plugin from "../";
 
 it("should have all the rules", () => {
-  expect(Object.keys(plugin.rules).length).toBeGreaterThan(0);
+  expect(Object.keys(plugin.rules)).toHaveLength(11);
 });
 
 it.each(Object.entries(plugin.rules))(

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,22 +1,76 @@
-import { generateRecommendedConfig, rules } from "../";
+import plugin from "../";
 
 it("should have all the rules", () => {
-  expect(Object.keys(rules).length).toBeGreaterThan(0);
+  expect(Object.keys(plugin.rules).length).toBeGreaterThan(0);
 });
 
-it.each(Object.keys(rules))("%s should export required fields", (ruleName) => {
-  const rule = rules[ruleName];
-  expect(rule).toHaveProperty("create", expect.any(Function));
-  expect(rule.meta.docs.url).not.toBe("");
-  expect(rule.meta.docs.category).toBe("Best Practices");
-  expect(rule.meta.docs.description).not.toBe("");
+it.each(Object.entries(plugin.rules))(
+  "%s should export required fields",
+  (name, rule) => {
+    expect(rule).toHaveProperty("create", expect.any(Function));
+    expect(rule.meta.docs.url).not.toBe("");
+    expect(rule.meta.docs.category).toBe("Best Practices");
+    expect(rule.meta.docs.description).not.toBe("");
+  }
+);
+
+it("has the expected recommended config", () => {
+  expect(plugin.configs.recommended).toMatchInlineSnapshot(`
+    Object {
+      plugins: Array [
+        jest-dom,
+      ],
+      rules: Object {
+        jest-dom/prefer-checked: error,
+        jest-dom/prefer-empty: error,
+        jest-dom/prefer-enabled-disabled: error,
+        jest-dom/prefer-focus: error,
+        jest-dom/prefer-in-document: error,
+        jest-dom/prefer-required: error,
+        jest-dom/prefer-to-have-attribute: error,
+        jest-dom/prefer-to-have-class: error,
+        jest-dom/prefer-to-have-style: error,
+        jest-dom/prefer-to-have-text-content: error,
+        jest-dom/prefer-to-have-value: error,
+      },
+    }
+  `);
 });
 
-it("should have a recommended config with recommended rules", () => {
-  expect(
-    generateRecommendedConfig({
-      good: { meta: { docs: { recommended: true } } },
-      bad: { meta: { docs: { recommended: false } } },
-    })
-  ).toEqual({ "jest-dom/good": "error" });
+it("has the expected recommended flat config", () => {
+  const expectJestDomPlugin = expect.objectContaining({
+    meta: {
+      name: "eslint-plugin-example",
+      version: expect.any(String),
+    },
+  });
+
+  expect(plugin.configs["flat/recommended"]).toMatchInlineSnapshot(
+    { plugins: { "jest-dom": expectJestDomPlugin } },
+    `
+    Object {
+      plugins: Object {
+        jest-dom: ObjectContaining {
+          meta: Object {
+            name: eslint-plugin-example,
+            version: Any<String>,
+          },
+        },
+      },
+      rules: Object {
+        jest-dom/prefer-checked: error,
+        jest-dom/prefer-empty: error,
+        jest-dom/prefer-enabled-disabled: error,
+        jest-dom/prefer-focus: error,
+        jest-dom/prefer-in-document: error,
+        jest-dom/prefer-required: error,
+        jest-dom/prefer-to-have-attribute: error,
+        jest-dom/prefer-to-have-class: error,
+        jest-dom/prefer-to-have-style: error,
+        jest-dom/prefer-to-have-text-content: error,
+        jest-dom/prefer-to-have-value: error,
+      },
+    }
+  `
+  );
 });

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -40,7 +40,7 @@ it("has the expected recommended config", () => {
 it("has the expected recommended flat config", () => {
   const expectJestDomPlugin = expect.objectContaining({
     meta: {
-      name: "eslint-plugin-example",
+      name: "eslint-plugin-jest-dom",
       version: expect.any(String),
     },
   });
@@ -52,7 +52,7 @@ it("has the expected recommended flat config", () => {
       plugins: Object {
         jest-dom: ObjectContaining {
           meta: Object {
-            name: eslint-plugin-example,
+            name: eslint-plugin-jest-dom,
             version: Any<String>,
           },
         },

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,4 +1,9 @@
-import { configs, rules } from "../";
+import plugin, { configs, rules } from "../";
+
+it("includes the configs and rules on the plugin", () => {
+  expect(plugin).toHaveProperty("configs", configs);
+  expect(plugin).toHaveProperty("rules", rules);
+});
 
 it("should have all the rules", () => {
   expect(Object.keys(rules)).toHaveLength(11);

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,10 +1,10 @@
-import plugin from "../";
+import { configs, rules } from "../";
 
 it("should have all the rules", () => {
-  expect(Object.keys(plugin.rules)).toHaveLength(11);
+  expect(Object.keys(rules)).toHaveLength(11);
 });
 
-it.each(Object.entries(plugin.rules))(
+it.each(Object.entries(rules))(
   "%s should export required fields",
   (name, rule) => {
     expect(rule).toHaveProperty("create", expect.any(Function));
@@ -15,7 +15,7 @@ it.each(Object.entries(plugin.rules))(
 );
 
 it("has the expected recommended config", () => {
-  expect(plugin.configs.recommended).toMatchInlineSnapshot(`
+  expect(configs.recommended).toMatchInlineSnapshot(`
     Object {
       plugins: Array [
         jest-dom,
@@ -45,7 +45,7 @@ it("has the expected recommended flat config", () => {
     },
   });
 
-  expect(plugin.configs["flat/recommended"]).toMatchInlineSnapshot(
+  expect(configs["flat/recommended"]).toMatchInlineSnapshot(
     { plugins: { "jest-dom": expectJestDomPlugin } },
     `
     Object {

--- a/src/index.js
+++ b/src/index.js
@@ -20,14 +20,6 @@ import {
 // import all rules in src/rules and re-export them for .eslintrc configs
 export const rules = requireIndex(`${__dirname}/rules`);
 
-const recommendedRules = Object.entries(rules).reduce(
-  (memo, [name, rule]) => ({
-    ...memo,
-    ...(rule.meta.docs.recommended ? { [`jest-dom/${name}`]: "error" } : {}),
-  }),
-  {}
-);
-
 const allRules = Object.entries(rules).reduce(
   (memo, [name]) => ({
     ...memo,
@@ -35,6 +27,8 @@ const allRules = Object.entries(rules).reduce(
   }),
   {}
 );
+
+const recommendedRules = allRules;
 
 const plugin = {
   meta: {

--- a/src/index.js
+++ b/src/index.js
@@ -14,33 +14,49 @@ import requireIndex from "requireindex";
 //------------------------------------------------------------------------------
 
 // import all rules in src/rules
-export const rules = requireIndex(`${__dirname}/rules`);
+const rules = requireIndex(`${__dirname}/rules`);
 
-export const generateRecommendedConfig = (allRules) =>
-  Object.entries(allRules).reduce(
-    (memo, [name, rule]) => ({
-      ...memo,
-      ...(rule.meta.docs.recommended ? { [`jest-dom/${name}`]: "error" } : {}),
-    }),
-    {}
-  );
+const recommendedRules = Object.entries(rules).reduce(
+  (memo, [name, rule]) => ({
+    ...memo,
+    ...(rule.meta.docs.recommended ? { [`jest-dom/${name}`]: "error" } : {}),
+  }),
+  {}
+);
 
-export const generateAllRulesConfig = (allRules) =>
-  Object.entries(allRules).reduce(
-    (memo, [name]) => ({
-      ...memo,
-      ...{ [`jest-dom/${name}`]: "error" },
-    }),
-    {}
-  );
+const allRules = Object.entries(rules).reduce(
+  (memo, [name]) => ({
+    ...memo,
+    ...{ [`jest-dom/${name}`]: "error" },
+  }),
+  {}
+);
 
-export const configs = {
-  recommended: {
-    plugins: ["jest-dom"],
-    rules: generateRecommendedConfig(rules),
+const plugin = {
+  meta: {
+    name: "eslint-plugin-example",
+    version: "1.0.0",
   },
-  all: {
-    plugins: ["jest-dom"],
-    rules: generateAllRulesConfig(rules),
+  configs: {
+    recommended: {
+      plugins: ["jest-dom"],
+      rules: recommendedRules,
+    },
+    all: {
+      plugins: ["jest-dom"],
+      rules: allRules,
+    },
   },
+  rules,
 };
+
+plugin.configs["flat/recommended"] = {
+  plugins: { "jest-dom": plugin },
+  rules: recommendedRules,
+};
+plugin.configs["flat/all"] = {
+  plugins: { "jest-dom": plugin },
+  rules: allRules,
+};
+
+export default plugin;

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,8 @@ import {
 // Plugin Definition
 //------------------------------------------------------------------------------
 
-// import all rules in src/rules
-const rules = requireIndex(`${__dirname}/rules`);
+// import all rules in src/rules and re-export them for .eslintrc configs
+export const rules = requireIndex(`${__dirname}/rules`);
 
 const recommendedRules = Object.entries(rules).reduce(
   (memo, [name, rule]) => ({
@@ -64,3 +64,8 @@ plugin.configs["flat/all"] = {
 };
 
 export default plugin;
+
+// explicitly export config to allow using this plugin in CJS-based
+// eslint.config.js files without needing to deal with the .default
+// and also retain backwards compatibility with `.eslintrc` configs
+export const configs = plugin.configs;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,10 @@
 //------------------------------------------------------------------------------
 
 import requireIndex from "requireindex";
+import {
+  name as packageName,
+  version as packageVersion,
+} from "../package.json";
 
 //------------------------------------------------------------------------------
 // Plugin Definition
@@ -34,8 +38,8 @@ const allRules = Object.entries(rules).reduce(
 
 const plugin = {
   meta: {
-    name: "eslint-plugin-example",
-    version: "1.0.0",
+    name: packageName,
+    version: packageVersion,
   },
   configs: {
     recommended: {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

This adds support for ESLint v9's upcoming `eslint.config.js` while retaining backwards compatibility with `.eslintrc` - I've marked this as a breaking change since I had to change around the exports due to needing to reference the plugin in the flat configs and in turn decided to axe the config building functions as there was no need to export them.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
