### PR TITLE
docs: update eslint suggestions links

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ module.exports = {
 💼 Configurations enabled in.\
 ✅ Set in the `recommended` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
-💡 Manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 
 | Name                                                                     | Description                                                           | 💼 | 🔧 | 💡 |
 | :----------------------------------------------------------------------- | :-------------------------------------------------------------------- | :- | :- | :- |

--- a/docs/rules/prefer-in-document.md
+++ b/docs/rules/prefer-in-document.md
@@ -2,7 +2,7 @@
 
 💼 This rule is enabled in the ✅ `recommended` config.
 
-🔧💡 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+🔧💡 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 
 <!-- end auto-generated rule header -->
 


### PR DESCRIPTION
For some reason these changes are wanted by CI but locally it wants the inverse