### PR TITLE
ci: update matrix of node versions to test against

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,12 +23,10 @@ jobs:
       fail-fast: false
       matrix:
         eslint: [6.8.0, 6, 7.0.0, 7, 8.0.0, 8]
-        node: [12.22.0, 12, 14.17.0, 14, 16.0.0, 16]
+        node: [12.x, 14.x, 16.x, 18.x, 20.x, 21.x]
         testing-library-dom: [8, 9]
         exclude:
-          - node: 12.22.0
-            testing-library-dom: 9
-          - node: 12
+          - node: 12.x
             testing-library-dom: 9
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This updates our matrix of Node versions to target the latest LTS versions of Node we support, optimizing CI to balance between giving us confidence in our support while still being easy to maintain; I'm comfortable not testing against exact versions since most people will be using the latest version within the particular major and really any issue would be the result of a bug in Node.