### PR TITLE
ci: only test against latest versions of ESLint majors

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        eslint: [6.8.0, 6, 7.0.0, 7, 8.0.0, 8]
+        eslint: [6, 7, 8]
         node: [12.x, 14.x, 16.x, 18.x, 20.x, 21.x]
         testing-library-dom: [8, 9]
         exclude:


### PR DESCRIPTION
This reduces the amount of jobs that get run without a lot of risk since users are generally going to be using the latest minor.patch version of a particular major, and any issues are going to be the result of bugs in that major for which any fix will require a new version anyway.