### PR TITLE
ci: don't run `@testing-library/dom` v10 against Node 12.x

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,12 +26,14 @@ jobs:
         node: [12.x, 14.x, 16.x, 18.x, 20.x, 21.x]
         testing-library-dom: [8, 9, 10]
         exclude:
-          - node: 12.x
-            testing-library-dom: 9
-          - node: 14.x
-            testing-library-dom: 10
-          - node: 16.x
-            testing-library-dom: 10
+          - testing-library-dom: 9
+            node: 12.x
+          - testing-library-dom: 10
+            node: 12.x
+          - testing-library-dom: 10
+            node: 14.x
+          - testing-library-dom: 10
+            node: 16.x
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo


### PR DESCRIPTION
While it isn't erroring, it's not officially supported and excluding it removes a couple more CI jobs - I've also changed the order so that the thing with the requirement is listed as the first key in each item, which makes it a bit more logic and that way we can be consistent.