### PR TITLE
fix(prefer-checked): don't flag `aria-checked="mixed"`

### DIFF
--- a/src/__tests__/lib/rules/no-attribute-checking.js
+++ b/src/__tests__/lib/rules/no-attribute-checking.js
@@ -50,3 +50,29 @@ bannedAttributes.forEach(
     });
   }
 );
+
+// Test that excludeValues ("mixed") are not flagged by prefer-checked
+const excludeValuesCases = [
+  {
+    ruleName: "prefer-checked",
+    attribute: "aria-checked",
+  },
+];
+
+excludeValuesCases.forEach(({ ruleName, attribute }) => {
+  const rule = require(`../../../rules/${ruleName}`);
+  const ruleTester = new RuleTester({
+    parserOptions: { ecmaVersion: 2015, sourceType: "module" },
+  });
+  ruleTester.run(`${ruleName} (excludeValues: mixed)`, rule, {
+    valid: [
+      `const el = screen.getByText("foo"); expect(el).toHaveAttribute("${attribute}", "mixed")`,
+      `const el = screen.getByText("foo"); expect(el).toHaveProperty("${attribute}", "mixed")`,
+      `const el = screen.getByText("foo"); expect(el).not.toHaveAttribute("${attribute}", "mixed")`,
+      `const el = screen.getByText("foo"); expect(el).not.toHaveProperty("${attribute}", "mixed")`,
+      `expect(getByText("foo")).toHaveAttribute("${attribute}", "mixed")`,
+      `expect(getByText("foo")).not.toHaveAttribute("${attribute}", "mixed")`,
+    ],
+    invalid: [],
+  });
+});

--- a/src/createBannedAttributeRule.js
+++ b/src/createBannedAttributeRule.js
@@ -1,6 +1,20 @@
 import { getQueryNodeFrom } from "./assignment-ast";
 
-export default ({ preferred, negatedPreferred, attributes }) => (context) => {
+export default ({
+  preferred,
+  negatedPreferred,
+  attributes,
+  excludeValues = [],
+}) => (context) => {
+  const isExcludedValue = (node) =>
+    excludeValues.length > 0 &&
+    node.arguments.length >= 2 &&
+    node.arguments[1].type === "Literal" &&
+    typeof node.arguments[1].value === "string" &&
+    excludeValues.some(
+      (v) => v.toLowerCase() === node.arguments[1].value.toLowerCase()
+    );
+
   const getCorrectFunctionFor = (node, negated = false) =>
     (node.arguments.length === 1 ||
       node.arguments[1].value === true ||
@@ -86,6 +100,10 @@ export default ({ preferred, negatedPreferred, attributes }) => (context) => {
         return;
       }
 
+      if (isExcludedValue(node)) {
+        return;
+      }
+
       const arg = node.arguments[0].value;
       const correctFunction = getCorrectFunctionFor(node, true);
 
@@ -106,6 +124,11 @@ export default ({ preferred, negatedPreferred, attributes }) => (context) => {
       if (!isBannedArg(node)) {
         return;
       }
+
+      if (isExcludedValue(node)) {
+        return;
+      }
+
       const { isDTLQuery } = getQueryNodeFrom(
         context,
         node.callee.object.arguments[0]

--- a/src/rules/prefer-checked.js
+++ b/src/rules/prefer-checked.js
@@ -19,4 +19,5 @@ export const create = createBannedAttributeRule({
   preferred: "toBeChecked",
   negatedPreferred: "not.toBeChecked",
   attributes: ["checked", "aria-checked"],
+  excludeValues: ["mixed"],
 });


### PR DESCRIPTION
**What**:

- Add `excludeValues` option to `createBannedAttributeRule` factory
- Apply `excludeValues: ["mixed"]` to `prefer-checked` to stop incorrectly flagging `aria-checked="mixed"`

**Why**:

The `prefer-checked` rule incorrectly suggests `not.toBeChecked()` when it encounters `toHaveAttribute('aria-checked', 'mixed')`. The value `"mixed"` is a valid third state for `aria-checked` (representing an indeterminate/partially-checked state) and should not be treated as falsy. The correct matcher for this case is `toBePartiallyChecked()`, which is outside the scope of `prefer-checked`.

**How**:

- Extended `createBannedAttributeRule` with an optional `excludeValues` parameter (defaults to `[]`)
- When a `toHaveAttribute`/`toHaveProperty` call has a second argument matching an excluded value, the rule skips it
- The change is backwards-compatible — existing rules without `excludeValues` behave identically

**Checklist**:

- [x] Documentation — N/A (no user-facing doc changes needed)
- [x] Tests
- [ ] Ready to be merged