### PR TITLE
fix: report style assertions with identifier values

### DIFF
--- a/src/__tests__/lib/rules/prefer-to-have-style.js
+++ b/src/__tests__/lib/rules/prefer-to-have-style.js
@@ -47,9 +47,19 @@ ruleTester.run("prefer-to-have-style", rule, {
       output: `expect(el).toHaveStyle({foo:"bar"})`,
     },
     {
+      code: `expect(el.style.color).toBe(red)`,
+      errors,
+      output: `expect(el).toHaveStyle({color:red})`,
+    },
+    {
       code: `expect(el.style.foo).not.toBe("bar")`,
       errors,
       output: `expect(el).not.toHaveStyle({foo:"bar"})`,
+    },
+    {
+      code: `expect(el.style.color).not.toBe(red)`,
+      errors,
+      output: `expect(el).not.toHaveStyle({color:red})`,
     },
     {
       code: "expect(el.style.backgroundImage).toBe(`url(${foo})`)",

--- a/src/rules/prefer-to-have-style.js
+++ b/src/rules/prefer-to-have-style.js
@@ -28,9 +28,9 @@ export const create = (context) => {
   }
   function getReplacementStyleParam(styleName, styleValue) {
     return styleName.type === "Literal"
-      ? `{${camelCase(styleName.value)}: ${context
-          .getSourceCode()
-          .getText(styleValue)}}`
+      ? `{${camelCase(styleName.value)}: ${getSourceCode(context).getText(
+          styleValue
+        )}}`
       : `${getSourceCode(context).getText(styleName).slice(0, -1)}: ${
           styleValue.type === "TemplateLiteral"
             ? getSourceCode(context).getText(styleValue).substring(1)
@@ -40,7 +40,7 @@ export const create = (context) => {
 
   return {
     //expect(el.style.foo).toBe("bar");
-    [`MemberExpression[property.name=style][parent.computed=false][parent.parent.parent.property.name=/toBe$|to(Strict)?Equal/][parent.parent.parent.parent.arguments.0.type=/(Template)?Literal/][parent.parent.callee.name=expect]`](
+    [`MemberExpression[property.name=style][parent.computed=false][parent.parent.parent.property.name=/toBe$|to(Strict)?Equal/][parent.parent.parent.parent.arguments.0.type=/((Template)?Literal|Identifier)/][parent.parent.callee.name=expect]`](
       node
     ) {
       const styleName = node.parent.property;
@@ -55,16 +55,16 @@ export const create = (context) => {
             fixer.replaceText(matcher, "toHaveStyle"),
             fixer.replaceText(
               styleValue,
-              `{${styleName.name}:${context
-                .getSourceCode()
-                .getText(styleValue)}}`
+              `{${styleName.name}:${getSourceCode(context).getText(
+                styleValue
+              )}}`
             ),
           ];
         },
       });
     },
     //expect(el.style.foo).not.toBe("bar");
-    [`MemberExpression[property.name=style][parent.computed=false][parent.parent.parent.property.name=not][parent.parent.parent.parent.property.name=/toBe$|to(Strict)?Equal/][parent.parent.parent.parent.parent.arguments.0.type=/(Template)?Literal$/][parent.parent.callee.name=expect]`](
+    [`MemberExpression[property.name=style][parent.computed=false][parent.parent.parent.property.name=not][parent.parent.parent.parent.property.name=/toBe$|to(Strict)?Equal/][parent.parent.parent.parent.parent.arguments.0.type=/((Template)?Literal|Identifier)$/][parent.parent.callee.name=expect]`](
       node
     ) {
       const styleName = node.parent.property;
@@ -79,9 +79,9 @@ export const create = (context) => {
             fixer.replaceText(matcher, "toHaveStyle"),
             fixer.replaceText(
               styleValue,
-              `{${styleName.name}:${context
-                .getSourceCode()
-                .getText(styleValue)}}`
+              `{${styleName.name}:${getSourceCode(context).getText(
+                styleValue
+              )}}`
             ),
           ];
         },
@@ -257,9 +257,9 @@ export const create = (context) => {
             fixer.replaceText(matcher, "toHaveStyle"),
             fixer.replaceTextRange(
               [styleName.range[0], styleValue.range[1]],
-              `{${getReplacementObjectProperty(styleName)}: ${context
-                .getSourceCode()
-                .getText(styleValue)}}`
+              `{${getReplacementObjectProperty(styleName)}: ${getSourceCode(
+                context
+              ).getText(styleValue)}}`
             ),
           ];
         },
@@ -289,9 +289,9 @@ export const create = (context) => {
             fixer.replaceText(matcher, "toHaveStyle"),
             fixer.replaceTextRange(
               [styleName.range[0], styleValue.range[1]],
-              `{${getReplacementObjectProperty(styleName)}: ${context
-                .getSourceCode()
-                .getText(styleValue)}}`
+              `{${getReplacementObjectProperty(styleName)}: ${getSourceCode(
+                context
+              ).getText(styleValue)}}`
             ),
           ];
         },


### PR DESCRIPTION
Fixes #384

This updates prefer-to-have-style to report dot-property style assertions when the expected value is an identifier.

Added regression coverage for both positive and negated assertions.

Tested with npm test -- prefer-to-have-style, npm run lint, and npm run validate.