### PR TITLE
fix(prefer-to-have-text-content): always pass strings to fixers

### DIFF
--- a/src/rules/prefer-to-have-text-content.js
+++ b/src/rules/prefer-to-have-text-content.js
@@ -40,7 +40,7 @@ export const create = (context) => ({
                     expectedArg.value
                       .toString()
                       .replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&")
-                  )
+                  ).toString()
               : `new RegExp(${expectedArgSource})`
           ),
         ];
@@ -100,7 +100,7 @@ export const create = (context) => ({
                   expectedArg.value
                     .toString()
                     .replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&")
-                )
+                ).toString()
             : `new RegExp(${expectedArgSource})`
         ),
       ],


### PR DESCRIPTION
It looks like prior to v10 fixers would implicitly call `toString`, but that's stopped happening now - also see https://github.com/G-Rath/eslint-plugin-jest-dom-ya/pull/6