### PR TITLE
feat: support replacing `mixed` value assertions with `toBePartiallyChecked` and `toBePartiallyPressed`

### DIFF
--- a/docs/rules/prefer-checked.md
+++ b/docs/rules/prefer-checked.md
@@ -14,8 +14,8 @@ This rule aims to prevent false positives and improve readability and should
 only be used with the `@testing-library/jest-dom` package. See below for
 examples of those potential issues and why this rule is recommended. The rule is
 autofixable and will replace any instances of `.toHaveProperty()` or
-`.toHaveAttribute()` with `.toBeChecked()` or `not.toBeChecked()` as
-appropriate.
+`.toHaveAttribute()` with `.toBeChecked()`, `.toBePartiallyChecked()`, and
+`not.toBeChecked()` as appropriate.
 
 ### False positives
 
@@ -60,6 +60,8 @@ expect(element).toHaveProperty("checked", something);
 expect(element).toHaveAttribute("checked");
 expect(element).not.toHaveProperty("checked");
 
+expect(element).not.toHaveProperty("aria-checked", "mixed");
+
 expect(element).not.not.toBeChecked();
 ```
 
@@ -73,6 +75,8 @@ expect(element).toBeChecked();
 expect(element).toHaveProperty("value", "foo");
 
 expect(element).toHaveAttribute("aria-label");
+
+expect(element).not.toBePartiallyChecked();
 ```
 
 ## When Not To Use It

--- a/docs/rules/prefer-pressed.md
+++ b/docs/rules/prefer-pressed.md
@@ -11,10 +11,8 @@
 This rule aims to prevent false positives and improve readability and should
 only be used with the `@testing-library/jest-dom` package. The rule is
 autofixable and will replace any instances of `.toHaveProperty()` or
-`.toHaveAttribute()` with `.toBePressed()` or `not.toBePressed()` as
-appropriate.
-
-Note: This rule does not flag checks for `aria-pressed="mixed"`.
+`.toHaveAttribute()` with `.toBePressed()`, `.toBePartiallyPressed()`, and
+`not.toBePressed()` as appropriate.
 
 Examples of **incorrect** code for this rule:
 
@@ -25,6 +23,8 @@ expect(element).toHaveProperty("aria-pressed", something);
 
 expect(element).toHaveAttribute("aria-pressed");
 expect(element).not.toHaveProperty("aria-pressed");
+
+expect(element).toHaveAttribute("aria-pressed", "mixed");
 
 expect(element).not.not.toBePressed();
 ```
@@ -38,7 +38,7 @@ expect(element).not.toBePressed();
 
 expect(element).toHaveAttribute("aria-label");
 
-expect(element).toHaveAttribute("aria-pressed", "mixed");
+expect(element).toBePartiallyPressed();
 ```
 
 ## When Not To Use It

--- a/src/__tests__/__fixtures__/createBannedAttributeTestCases.js
+++ b/src/__tests__/__fixtures__/createBannedAttributeTestCases.js
@@ -125,6 +125,15 @@ export default ({ preferred, negatedPreferred, mixedPreferred, attribute }) => {
           output: `const el = screen.getByText("foo"); expect(el).not.${mixedPreferred}`,
         },
         {
+          code: `const el = screen.getByText("foo"); expect(el).not.toHaveAttribute('${attribute}', 'Mixed')`,
+          errors: [
+            {
+              message: `Use not.${mixedPreferred} instead of not.toHaveAttribute('${attribute}', 'Mixed')`,
+            },
+          ],
+          output: `const el = screen.getByText("foo"); expect(el).not.${mixedPreferred}`,
+        },
+        {
           code: `const el = screen.getByText("foo"); expect(el).not.toHaveProperty('${attribute}', 'mixed')`,
           errors: [
             {

--- a/src/__tests__/__fixtures__/createBannedAttributeTestCases.js
+++ b/src/__tests__/__fixtures__/createBannedAttributeTestCases.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines-per-function */
 
-export default ({ preferred, negatedPreferred, attribute }) => {
+export default ({ preferred, negatedPreferred, mixedPreferred, attribute }) => {
+  // covers toBeDisabled / toBeEnabled
   const doubleNegativeCases = negatedPreferred.startsWith("toBe")
     ? [
         {
@@ -50,6 +51,8 @@ export default ({ preferred, negatedPreferred, attribute }) => {
         },
       ]
     : [];
+
+  // covers not aria-* type attributes
   const directChecks = /-/.test(attribute)
     ? []
     : [
@@ -91,6 +94,74 @@ export default ({ preferred, negatedPreferred, attribute }) => {
         },
       ];
 
+  // covers partial matchers for aria-<attribute>=mixed
+  const mixedChecks = mixedPreferred
+    ? [
+        {
+          code: `const el = screen.getByText("foo"); expect(el).toHaveProperty('${attribute}', 'mixed')`,
+          errors: [
+            {
+              message: `Use ${mixedPreferred} instead of toHaveProperty('${attribute}', 'mixed')`,
+            },
+          ],
+          output: `const el = screen.getByText("foo"); expect(el).${mixedPreferred}`,
+        },
+        {
+          code: `const el = screen.getByText("foo"); expect(el).toHaveAttribute('${attribute}', 'mixed')`,
+          errors: [
+            {
+              message: `Use ${mixedPreferred} instead of toHaveAttribute('${attribute}', 'mixed')`,
+            },
+          ],
+          output: `const el = screen.getByText("foo"); expect(el).${mixedPreferred}`,
+        },
+        {
+          code: `const el = screen.getByText("foo"); expect(el).not.toHaveAttribute('${attribute}', 'mixed')`,
+          errors: [
+            {
+              message: `Use not.${mixedPreferred} instead of not.toHaveAttribute('${attribute}', 'mixed')`,
+            },
+          ],
+          output: `const el = screen.getByText("foo"); expect(el).not.${mixedPreferred}`,
+        },
+        {
+          code: `const el = screen.getByText("foo"); expect(el).not.toHaveProperty('${attribute}', 'mixed')`,
+          errors: [
+            {
+              message: `Use not.${mixedPreferred} instead of not.toHaveProperty('${attribute}', 'mixed')`,
+            },
+          ],
+          output: `const el = screen.getByText("foo"); expect(el).not.${mixedPreferred}`,
+        },
+        {
+          code: `expect(getByText("foo")).toHaveAttribute("${attribute}", "mixed")`,
+          errors: [
+            {
+              message: `Use ${mixedPreferred} instead of toHaveAttribute("${attribute}", "mixed")`,
+            },
+          ],
+          output: `expect(getByText("foo")).${mixedPreferred}`,
+        },
+        {
+          code: `expect(getByText("foo")).not.toHaveProperty("${attribute}", "mixed")`,
+          errors: [
+            {
+              message: `Use not.${mixedPreferred} instead of not.toHaveProperty("${attribute}", "mixed")`,
+            },
+          ],
+          output: `expect(getByText("foo")).not.${mixedPreferred}`,
+        },
+        {
+          code: `const el = getByRole("button", { name: 'My Button' }); expect(el).toHaveProperty('${attribute}', 'mixed')`,
+          errors: [
+            {
+              message: `Use ${mixedPreferred} instead of toHaveProperty('${attribute}', 'mixed')`,
+            },
+          ],
+        },
+      ]
+    : [];
+
   return {
     valid: [
       `expect().not.toHaveProperty('value', 'foo')`,
@@ -101,10 +172,20 @@ export default ({ preferred, negatedPreferred, attribute }) => {
       `const el = foo.bar(); expect(el).toHaveProperty("${attribute}", true)`,
       `expect(getFoo().${attribute}).toBe("bar")`,
       `expect(getFoo().${attribute}).not.toBe("bar")`,
+      ...(mixedPreferred
+        ? [
+            `expect(getFoo().${attribute}).toBe("mixed")`,
+            `expect(getFoo().${attribute}).not.toBe("mixed")`,
+            `const el = screen.getByText("foo"); expect(el).${mixedPreferred}`,
+            `const el = screen.getByText("foo"); expect(el).not.${mixedPreferred}`,
+            `const el = foo.bar(); expect(el).toHaveProperty("${attribute}", 'mixed')`,
+          ]
+        : []),
     ],
     invalid: [
       ...doubleNegativeCases,
       ...directChecks,
+      ...mixedChecks,
       {
         code: `const el = screen.getByText("foo"); expect(el).toHaveProperty('${attribute}', true)`,
         errors: [

--- a/src/__tests__/__fixtures__/createBannedAttributeTestCases.js
+++ b/src/__tests__/__fixtures__/createBannedAttributeTestCases.js
@@ -158,6 +158,7 @@ export default ({ preferred, negatedPreferred, mixedPreferred, attribute }) => {
               message: `Use ${mixedPreferred} instead of toHaveProperty('${attribute}', 'mixed')`,
             },
           ],
+          output: `const el = getByRole("button", { name: 'My Button' }); expect(el).${mixedPreferred}`,
         },
       ]
     : [];

--- a/src/__tests__/lib/rules/no-attribute-checking.js
+++ b/src/__tests__/lib/rules/no-attribute-checking.js
@@ -22,6 +22,7 @@ const bannedAttributes = [
   {
     preferred: "toBeChecked()",
     negatedPreferred: "not.toBeChecked()",
+    mixedPreferred: "toBePartiallyChecked()",
     attributes: ["checked", "aria-checked"],
     ruleName: "prefer-checked",
   },
@@ -57,10 +58,6 @@ bannedAttributes.forEach(
 
 // Test that excludeValues ("mixed") are not flagged by prefer-checked
 const excludeValuesCases = [
-  {
-    ruleName: "prefer-checked",
-    attribute: "aria-checked",
-  },
   {
     ruleName: "prefer-pressed",
     attribute: "aria-pressed",

--- a/src/__tests__/lib/rules/no-attribute-checking.js
+++ b/src/__tests__/lib/rules/no-attribute-checking.js
@@ -34,12 +34,9 @@ const bannedAttributes = [
 ];
 
 bannedAttributes.forEach(
-  ({ preferred, negatedPreferred, attributes, ruleName }) => {
+  ({ preferred, negatedPreferred, mixedPreferred, attributes, ruleName }) => {
     const rule = require(`../../../rules/${ruleName}`);
 
-    // const preferred = 'toBeDisabled()';
-    // const negatedPreferred = 'toBeEnabled()';
-    // const attributes = ['disabled'];
     const ruleTester = new RuleTester({
       parserOptions: { ecmaVersion: 2015, sourceType: "module" },
     });
@@ -50,6 +47,7 @@ bannedAttributes.forEach(
         createBannedAttributeTestCases({
           preferred,
           negatedPreferred,
+          mixedPreferred,
           attribute,
         })
       );

--- a/src/__tests__/lib/rules/no-attribute-checking.js
+++ b/src/__tests__/lib/rules/no-attribute-checking.js
@@ -29,6 +29,7 @@ const bannedAttributes = [
   {
     preferred: "toBePressed()",
     negatedPreferred: "not.toBePressed()",
+    mixedPreferred: "toBePartiallyPressed()",
     attributes: ["aria-pressed"],
     ruleName: "prefer-pressed",
   },
@@ -55,29 +56,3 @@ bannedAttributes.forEach(
     });
   }
 );
-
-// Test that excludeValues ("mixed") are not flagged by prefer-checked
-const excludeValuesCases = [
-  {
-    ruleName: "prefer-pressed",
-    attribute: "aria-pressed",
-  },
-];
-
-excludeValuesCases.forEach(({ ruleName, attribute }) => {
-  const rule = require(`../../../rules/${ruleName}`);
-  const ruleTester = new RuleTester({
-    parserOptions: { ecmaVersion: 2015, sourceType: "module" },
-  });
-  ruleTester.run(`${ruleName} (excludeValues: mixed)`, rule, {
-    valid: [
-      `const el = screen.getByText("foo"); expect(el).toHaveAttribute("${attribute}", "mixed")`,
-      `const el = screen.getByText("foo"); expect(el).toHaveProperty("${attribute}", "mixed")`,
-      `const el = screen.getByText("foo"); expect(el).not.toHaveAttribute("${attribute}", "mixed")`,
-      `const el = screen.getByText("foo"); expect(el).not.toHaveProperty("${attribute}", "mixed")`,
-      `expect(getByText("foo")).toHaveAttribute("${attribute}", "mixed")`,
-      `expect(getByText("foo")).not.toHaveAttribute("${attribute}", "mixed")`,
-    ],
-    invalid: [],
-  });
-});

--- a/src/createBannedAttributeRule.js
+++ b/src/createBannedAttributeRule.js
@@ -19,16 +19,17 @@ export default ({ preferred, negatedPreferred, mixedPreferred, attributes }) =>
 
     const getCorrectFunctionFor = (node, negated = false) => {
       const value = findSecondStringLiteralArgumentValue(node);
+      const isMixed = mixedPreferred && (value || "").toLowerCase() === "mixed";
 
       if (negated) {
-        if (mixedPreferred && value === "mixed") {
+        if (isMixed) {
           return `not.${mixedPreferred}`;
         }
 
         return negatedPreferred;
       }
 
-      if (mixedPreferred && value === "mixed") {
+      if (isMixed) {
         return mixedPreferred;
       }
 

--- a/src/createBannedAttributeRule.js
+++ b/src/createBannedAttributeRule.js
@@ -21,30 +21,26 @@ export default ({ preferred, negatedPreferred, mixedPreferred, attributes }) =>
       const value = findSecondStringLiteralArgumentValue(node);
       const isMixed = mixedPreferred && (value || "").toLowerCase() === "mixed";
 
-      if (negated) {
-        if (isMixed) {
-          return `not.${mixedPreferred}`;
-        }
+      if (isMixed) {
+        return negated ? `not.${mixedPreferred}` : mixedPreferred;
+      }
 
+      // use the negated preference if we're _not_ using a truthy value,
+      // or we have been told we're negated // todo: this might be a bug?
+      if (
+        negated ||
+        !(
+          node.arguments.length === 1 ||
+          node.arguments[1].value === true ||
+          node.arguments[1].type !== "Literal" ||
+          (value || "").toLowerCase() === "true" ||
+          node.arguments[1].value === ""
+        )
+      ) {
         return negatedPreferred;
       }
 
-      if (isMixed) {
-        return mixedPreferred;
-      }
-
-      const isTruthy =
-        node.arguments.length === 1 ||
-        node.arguments[1].value === true ||
-        node.arguments[1].type !== "Literal" ||
-        (value || "").toLowerCase() === "true" ||
-        node.arguments[1].value === "";
-
-      if (isTruthy) {
-        return preferred;
-      }
-
-      return negatedPreferred;
+      return preferred;
     };
 
     const isBannedArg = (node) =>

--- a/src/createBannedAttributeRule.js
+++ b/src/createBannedAttributeRule.js
@@ -3,29 +3,68 @@ import { getQueryNodeFrom } from "./assignment-ast";
 export default ({
     preferred,
     negatedPreferred,
+    mixedPreferred,
     attributes,
     excludeValues = [],
   }) =>
   (context) => {
-    const isExcludedValue = (node) =>
-      excludeValues.length > 0 &&
-      node.arguments.length >= 2 &&
-      node.arguments[1].type === "Literal" &&
-      typeof node.arguments[1].value === "string" &&
-      excludeValues.some(
-        (v) => v.toLowerCase() === node.arguments[1].value.toLowerCase()
-      );
+    /**
+     * Returns the value of the second argument of the given node, if it's a string literal
+     * or otherwise null
+     *
+     * @param node
+     *
+     * @return {string | null}
+     */
+    const findSecondStringLiteralArgumentValue = (node) =>
+      (node.arguments.length >= 2 &&
+        node.arguments[1].type === "Literal" &&
+        typeof node.arguments[1].value === "string" &&
+        node.arguments[1].value) ||
+      null;
 
-    const getCorrectFunctionFor = (node, negated = false) =>
-      (node.arguments.length === 1 ||
+    const isExcludedValue = (node) => {
+      if (!excludeValues.length) {
+        return false;
+      }
+
+      const value = findSecondStringLiteralArgumentValue(node);
+
+      if (!value) {
+        return false;
+      }
+
+      return excludeValues.some((v) => v.toLowerCase() === value.toLowerCase());
+    };
+
+    const getCorrectFunctionFor = (node, negated = false) => {
+      const value = findSecondStringLiteralArgumentValue(node);
+
+      if (negated) {
+        if (mixedPreferred && value === "mixed") {
+          return `not.${mixedPreferred}`;
+        }
+
+        return negatedPreferred;
+      }
+
+      if (mixedPreferred && value === "mixed") {
+        return mixedPreferred;
+      }
+
+      const isTruthy =
+        node.arguments.length === 1 ||
         node.arguments[1].value === true ||
         node.arguments[1].type !== "Literal" ||
-        (typeof node.arguments[1].value === "string" &&
-          node.arguments[1].value.toLowerCase() === "true") ||
-        node.arguments[1].value === "") &&
-      !negated
-        ? preferred
-        : negatedPreferred;
+        (value || "").toLowerCase() === "true" ||
+        node.arguments[1].value === "";
+
+      if (isTruthy) {
+        return preferred;
+      }
+
+      return negatedPreferred;
+    };
 
     const isBannedArg = (node) =>
       node.arguments.length &&

--- a/src/createBannedAttributeRule.js
+++ b/src/createBannedAttributeRule.js
@@ -1,12 +1,6 @@
 import { getQueryNodeFrom } from "./assignment-ast";
 
-export default ({
-    preferred,
-    negatedPreferred,
-    mixedPreferred,
-    attributes,
-    excludeValues = [],
-  }) =>
+export default ({ preferred, negatedPreferred, mixedPreferred, attributes }) =>
   (context) => {
     /**
      * Returns the value of the second argument of the given node, if it's a string literal
@@ -22,20 +16,6 @@ export default ({
         typeof node.arguments[1].value === "string" &&
         node.arguments[1].value) ||
       null;
-
-    const isExcludedValue = (node) => {
-      if (!excludeValues.length) {
-        return false;
-      }
-
-      const value = findSecondStringLiteralArgumentValue(node);
-
-      if (!value) {
-        return false;
-      }
-
-      return excludeValues.some((v) => v.toLowerCase() === value.toLowerCase());
-    };
 
     const getCorrectFunctionFor = (node, negated = false) => {
       const value = findSecondStringLiteralArgumentValue(node);
@@ -141,10 +121,6 @@ export default ({
           return;
         }
 
-        if (isExcludedValue(node)) {
-          return;
-        }
-
         const correctFunction = getCorrectFunctionFor(node, true);
 
         const incorrectFunction = node.callee.property.name;
@@ -167,10 +143,6 @@ export default ({
         node
       ) {
         if (!isBannedArg(node)) {
-          return;
-        }
-
-        if (isExcludedValue(node)) {
           return;
         }
 

--- a/src/rules/prefer-checked.js
+++ b/src/rules/prefer-checked.js
@@ -18,6 +18,6 @@ export const meta = {
 export const create = createBannedAttributeRule({
   preferred: "toBeChecked",
   negatedPreferred: "not.toBeChecked",
+  mixedPreferred: "toBePartiallyChecked",
   attributes: ["checked", "aria-checked"],
-  excludeValues: ["mixed"],
 });

--- a/src/rules/prefer-pressed.js
+++ b/src/rules/prefer-pressed.js
@@ -17,6 +17,6 @@ export const meta = {
 export const create = createBannedAttributeRule({
   preferred: "toBePressed",
   negatedPreferred: "not.toBePressed",
+  mixedPreferred: "toBePartiallyPressed",
   attributes: ["aria-pressed"],
-  excludeValues: ["mixed"],
 });


### PR DESCRIPTION
Note I'm purposely ignoring the fact that this will also trigger on `checked="mixed"` since these rules are already a bit shaky in ways that I think should be addressed through dedicated fixes, and ultimately I think in that situation it'd still be reasonable for us to switch to the "partially" matcher

Resolves #43