### PR TITLE
feat(prefer-to-have-value): support `aria-valuenow`

### DIFF
--- a/docs/rules/prefer-to-have-value.md
+++ b/docs/rules/prefer-to-have-value.md
@@ -21,7 +21,9 @@ Examples of **incorrect** code for this rule:
 ```js
 expect(element).toHaveAttribute("value", "foo");
 expect(element).toHaveProperty("value", "foo");
+expect(element).toHaveProperty("aria-valuenow", "foo");
 expect(element.value).toBe("foo");
+expect(element["aria-valuenow"]).toBe("foo");
 expect(element.value).not.toEqual("foo");
 expect(element.value).not.toStrictEqual("foo");
 ```

--- a/src/__tests__/lib/rules/prefer-to-have-value.js
+++ b/src/__tests__/lib/rules/prefer-to-have-value.js
@@ -29,8 +29,13 @@ ruleTester.run("prefer-to-have-value", rule, {
     `expect(element.value).toBeGreaterThan(2);`,
     `expect(element.value).toBeLessThan(2);`,
 
+    `expect(element).toHaveAttribute('my-value', 'foo')`,
+
     `const element = document.getElementById('asdfasf');
     expect(element.value).toEqual('foo');`,
+
+    `const element = document.getElementById('asdfasf');
+    expect(element['aria-valuenow']).toEqual('foo');`,
 
     `let element;
     element = someOtherFunction();
@@ -50,6 +55,10 @@ ruleTester.run("prefer-to-have-value", rule, {
     element = someOtherFunction();
     expect(element.value).not.toStrictEqual('foo');`,
 
+    `let element;
+    element = someOtherFunction();
+    expect(element['aria-valuenow']).not.toStrictEqual('foo');`,
+
     `const element = { value: 'foo' };
     expect(element.value).not.toBe('foo');`,
     `
@@ -64,7 +73,17 @@ ruleTester.run("prefer-to-have-value", rule, {
       output: `expect(element).toHaveValue('foo')`,
     },
     {
+      code: `expect(element).toHaveAttribute('aria-valuenow', 'foo')`,
+      errors,
+      output: `expect(element).toHaveValue('foo')`,
+    },
+    {
       code: `expect(element).toHaveProperty("value", "foo")`,
+      errors,
+      output: `expect(element).toHaveValue("foo")`,
+    },
+    {
+      code: `expect(element).toHaveProperty("aria-valuenow", "foo")`,
       errors,
       output: `expect(element).toHaveValue("foo")`,
     },
@@ -74,7 +93,17 @@ ruleTester.run("prefer-to-have-value", rule, {
       output: `expect(element).not.toHaveValue('foo')`,
     },
     {
+      code: `expect(element).not.toHaveAttribute('aria-valuenow', 'foo')`,
+      errors,
+      output: `expect(element).not.toHaveValue('foo')`,
+    },
+    {
       code: `expect(element).not.toHaveProperty("value", "foo")`,
+      errors,
+      output: `expect(element).not.toHaveValue("foo")`,
+    },
+    {
+      code: `expect(element).not.toHaveProperty("aria-valuenow", "foo")`,
       errors,
       output: `expect(element).not.toHaveValue("foo")`,
     },
@@ -83,6 +112,16 @@ ruleTester.run("prefer-to-have-value", rule, {
       code: `expect(screen.getByRole("textbox").value).toEqual("foo")`,
       errors,
       output: `expect(screen.getByRole("textbox")).toHaveValue("foo")`,
+    },
+    {
+      code: `expect(screen.getByRole("textbox")['aria-valuenow']).toEqual("foo")`,
+      errors,
+      output: `expect(screen.getByRole("textbox")).toHaveValue("foo")`,
+    },
+    {
+      code: `expect(screen.getByRole("textbox")[ 'aria-valuenow'] /* comment */).toEqual("foo")`,
+      errors,
+      output: `expect(screen.getByRole("textbox")  /* comment */).toHaveValue("foo")`,
     },
     {
       code: `expect(screen.queryByRole("dropdown").value).toEqual("foo")`,
@@ -105,12 +144,27 @@ ruleTester.run("prefer-to-have-value", rule, {
       output: `expect(screen.getByRole("textbox")).not.toHaveValue("foo")`,
     },
     {
+      code: `expect(screen.getByRole("textbox")['aria-valuenow']).not.toEqual("foo")`,
+      errors,
+      output: `expect(screen.getByRole("textbox")).not.toHaveValue("foo")`,
+    },
+    {
+      code: `expect(screen.getByRole("textbox")[ 'aria-valuenow' ]).not.toEqual("foo")`,
+      errors,
+      output: `expect(screen.getByRole("textbox")  ).not.toHaveValue("foo")`,
+    },
+    {
       code: `expect(screen.queryByRole("dropdown").value).not.toEqual("foo")`,
       errors,
       output: `expect(screen.queryByRole("dropdown")).not.toHaveValue("foo")`,
     },
     {
       code: `async function x() { expect((await screen.getByRole("textbox")).value).not.toEqual("foo") }`,
+      errors,
+      output: `async function x() { expect((await screen.getByRole("textbox"))).not.toHaveValue("foo") }`,
+    },
+    {
+      code: `async function x() { expect((await screen.getByRole("textbox"))['aria-valuenow']).not.toEqual("foo") }`,
       errors,
       output: `async function x() { expect((await screen.getByRole("textbox"))).not.toHaveValue("foo") }`,
     },

--- a/src/rules/prefer-to-have-value.js
+++ b/src/rules/prefer-to-have-value.js
@@ -63,6 +63,32 @@ export const create = (context) => {
       }
     },
 
+    // expect(element['aria-valuenow']).toBe('foo') / toEqual / toStrictEqual
+    // expect(<query>['aria-valuenow']).toBe('foo') / toEqual / toStrictEqual
+    // expect((await <query>)['aria-valuenow']).toBe('foo') / toEqual / toStrictEqual
+    [`CallExpression[callee.property.name=/to(Be|(Strict)?Equal)$/][callee.object.arguments.0.property.value='aria-valuenow'][callee.object.callee.name=expect]`](
+      node
+    ) {
+      const valueProp = node.callee.object.arguments[0].property;
+      const matcher = node.callee.property;
+      const queryNode = node.callee.object.arguments[0].object;
+
+      if (isValidQueryNode(queryNode)) {
+        context.report({
+          messageId,
+          node,
+          fix(fixer) {
+            return [
+              fixer.remove(getSourceCode(context).getTokenBefore(valueProp)),
+              fixer.remove(getSourceCode(context).getTokenAfter(valueProp)),
+              fixer.remove(valueProp),
+              fixer.replaceText(matcher, "toHaveValue"),
+            ];
+          },
+        });
+      }
+    },
+
     // expect(element.value).not.toBe('foo') / toEqual / toStrictEqual
     // expect(<query>.value).not.toBe('foo') / toEqual / toStrictEqual
     // expect((await <query>).value).not.toBe('foo') / toEqual / toStrictEqual
@@ -90,8 +116,35 @@ export const create = (context) => {
       }
     },
 
+    // expect(element['aria-valuenow']).not.toBe('foo') / toEqual / toStrictEqual
+    // expect(<query>['aria-valuenow']).not.toBe('foo') / toEqual / toStrictEqual
+    // expect((await <query>)['aria-valuenow']).not.toBe('foo') / toEqual / toStrictEqual
+    [`CallExpression[callee.property.name=/to(Be|(Strict)?Equal)$/][callee.object.object.callee.name=expect][callee.object.property.name=not][callee.object.object.arguments.0.property.value='aria-valuenow']`](
+      node
+    ) {
+      const queryNode = node.callee.object.object.arguments[0].object;
+      const valueProp = node.callee.object.object.arguments[0].property;
+      const matcher = node.callee.property;
+
+      if (isValidQueryNode(queryNode)) {
+        context.report({
+          messageId,
+          node,
+          fix(fixer) {
+            return [
+              fixer.remove(getSourceCode(context).getTokenBefore(valueProp)),
+              fixer.remove(getSourceCode(context).getTokenAfter(valueProp)),
+              fixer.remove(valueProp),
+              fixer.replaceText(matcher, "toHaveValue"),
+            ];
+          },
+        });
+      }
+    },
+
     //expect(element).toHaveAttribute('value', 'foo')  / Property
-    [`CallExpression[callee.property.name=/toHave(Attribute|Property)/][arguments.0.value=value][arguments.1][callee.object.callee.name=expect], CallExpression[callee.property.name=/toHave(Attribute|Property)/][arguments.0.value=value][arguments.1][callee.object.object.callee.name=expect][callee.object.property.name=not]`](
+    //expect(element).toHaveAttribute('aria-valuenow', 'foo')  / Property
+    [`CallExpression[callee.property.name=/toHave(Attribute|Property)/][arguments.0.value=/^(value|aria-valuenow)$/][arguments.1][callee.object.callee.name=expect], CallExpression[callee.property.name=/toHave(Attribute|Property)/][arguments.0.value=/(value|aria-valuenow)$/][arguments.1][callee.object.object.callee.name=expect][callee.object.property.name=not]`](
       node
     ) {
       const matcher = node.callee.property;


### PR DESCRIPTION
Even though this is only for ranges, I think it's fine to autocorrect any use of it

Relates to #43 (sort of)