### PR TITLE
chore: remove `prettierignore` file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,0 @@
-node_modules
-coverage
-dist
-.cache-eslint-remote-tester
-eslint-remote-tester-results


### PR DESCRIPTION
Prettier always reads from `.gitignore` (even if there's a `.pretterignore`), so we don't need this