### PR TITLE
feat: remove unneeded `@babel/runtime` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "test:update": "npm test:coverage -- --updateSnapshot"
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.3",
     "requireindex": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Turns out I had mistakenly removed this "optimization" in #454, but I didn't realize because the total build size is _exactly_ the same since we're using a single one-line function - so ultimately this is actually _adding_ to the overall size since it pulls in a couple of packages