### PR TITLE
fix(prefer-to-have-text-content): preserve exact text assertions

### DIFF
--- a/src/__tests__/lib/rules/prefer-to-have-text-content.test.js
+++ b/src/__tests__/lib/rules/prefer-to-have-text-content.test.js
@@ -22,6 +22,8 @@ ruleTester.run("prefer-to-have-text-content", rule, {
     `expect(string).toBe("foo")`,
     `expect(element).toHaveTextContent("foo")`,
     `expect(container.lastNode).toBe("foo")`,
+    `expect(element.textContent).toEqualThing("foo")`,
+    `expect(element.textContent).not.toStrictEqualThing("foo")`,
   ],
 
   invalid: [
@@ -33,7 +35,47 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: `expect(element).toHaveTextContent("foo")`,
+      output: `expect(element).toHaveTextContent(/^foo$/)`,
+    },
+    {
+      code: 'expect(element.textContent).toBe("a.b [x] / y?")',
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: String.raw`expect(element).toHaveTextContent(/^a\.b \[x\] \/ y\?$/)`,
+    },
+    {
+      code: "expect(element.textContent).toBe(`foo`)",
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: `expect(element).toHaveTextContent(/^foo$/)`,
+    },
+    {
+      code: "expect(element.textContent).toBe(`hello ${name}`)",
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: null,
+    },
+    {
+      code: "expect(element.textContent).toBe(text)",
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: null,
     },
     {
       code: 'expect(element.textContent).not.toBe("foo")',
@@ -43,7 +85,7 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: `expect(element).not.toHaveTextContent("foo")`,
+      output: `expect(element).not.toHaveTextContent(/^foo$/)`,
     },
     {
       code: 'expect(screen.getByText("foo").textContent).toBe("foo")',
@@ -53,7 +95,7 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: `expect(screen.getByText("foo")).toHaveTextContent("foo")`,
+      output: `expect(screen.getByText("foo")).toHaveTextContent(/^foo$/)`,
     },
     {
       code: 'expect(container.firstChild.textContent).toBe("foo")',
@@ -63,7 +105,7 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: `expect(container.firstChild).toHaveTextContent("foo")`,
+      output: `expect(container.firstChild).toHaveTextContent(/^foo$/)`,
     },
     {
       code: 'expect(element.textContent).toEqual("foo")',
@@ -73,7 +115,17 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: `expect(element).toHaveTextContent("foo")`,
+      output: `expect(element).toHaveTextContent(/^foo$/)`,
+    },
+    {
+      code: 'expect(element.textContent).toStrictEqual("foo")',
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: `expect(element).toHaveTextContent(/^foo$/)`,
     },
     {
       code: 'expect(element.textContent).toContain("foo")',

--- a/src/__tests__/lib/rules/prefer-to-have-text-content.test.js
+++ b/src/__tests__/lib/rules/prefer-to-have-text-content.test.js
@@ -78,6 +78,16 @@ ruleTester.run("prefer-to-have-text-content", rule, {
       output: null,
     },
     {
+      code: "expect(element.textContent).toBe()",
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: null,
+    },
+    {
       code: 'expect(element.textContent).not.toBe("foo")',
       errors: [
         {
@@ -86,6 +96,16 @@ ruleTester.run("prefer-to-have-text-content", rule, {
         },
       ],
       output: `expect(element).not.toHaveTextContent(/^foo$/)`,
+    },
+    {
+      code: "expect(element.textContent).not.toBe(text)",
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: null,
     },
     {
       code: 'expect(screen.getByText("foo").textContent).toBe("foo")',

--- a/src/__tests__/lib/rules/prefer-to-have-text-content.test.js
+++ b/src/__tests__/lib/rules/prefer-to-have-text-content.test.js
@@ -35,7 +35,7 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: `expect(element).toHaveTextContent(/^foo$/)`,
+      output: null,
     },
     {
       code: 'expect(element.textContent).toBe("a.b [x] / y?")',
@@ -45,7 +45,7 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: String.raw`expect(element).toHaveTextContent(/^a\.b \[x\] \/ y\?$/)`,
+      output: null,
     },
     {
       code: "expect(element.textContent).toBe(`foo`)",
@@ -55,7 +55,7 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: `expect(element).toHaveTextContent(/^foo$/)`,
+      output: null,
     },
     {
       code: "expect(element.textContent).toBe(`hello ${name}`)",
@@ -95,7 +95,7 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: `expect(element).not.toHaveTextContent(/^foo$/)`,
+      output: null,
     },
     {
       code: "expect(element.textContent).not.toBe(text)",
@@ -115,7 +115,7 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: `expect(screen.getByText("foo")).toHaveTextContent(/^foo$/)`,
+      output: null,
     },
     {
       code: 'expect(container.firstChild.textContent).toBe("foo")',
@@ -125,7 +125,7 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: `expect(container.firstChild).toHaveTextContent(/^foo$/)`,
+      output: null,
     },
     {
       code: 'expect(element.textContent).toEqual("foo")',
@@ -135,7 +135,7 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: `expect(element).toHaveTextContent(/^foo$/)`,
+      output: null,
     },
     {
       code: 'expect(element.textContent).toStrictEqual("foo")',
@@ -145,7 +145,7 @@ ruleTester.run("prefer-to-have-text-content", rule, {
             "Use toHaveTextContent instead of asserting on DOM node attributes",
         },
       ],
-      output: `expect(element).toHaveTextContent(/^foo$/)`,
+      output: null,
     },
     {
       code: 'expect(element.textContent).toContain("foo")',

--- a/src/rules/prefer-to-have-text-content.js
+++ b/src/rules/prefer-to-have-text-content.js
@@ -4,6 +4,40 @@
  */
 import { getSourceCode } from "../context";
 
+const escapeForRegexLiteral = (value) =>
+  value
+    .toString()
+    .replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\//g, "\\/")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+const getExactReplacementPattern = (expectedArg) => {
+  if (!expectedArg) {
+    return null;
+  }
+
+  if (expectedArg.type === "Literal" && typeof expectedArg.value === "string") {
+    return `/^${escapeForRegexLiteral(expectedArg.value)}$/`;
+  }
+
+  if (
+    expectedArg.type === "TemplateLiteral" &&
+    expectedArg.expressions.length === 0
+  ) {
+    const cookedValue = expectedArg.quasis[0].value.cooked;
+
+    if (cookedValue === null) {
+      return null;
+    }
+
+    return `/^${escapeForRegexLiteral(cookedValue)}$/`;
+  }
+
+  return null;
+};
+
 export const meta = {
   docs: {
     category: "Best Practices",
@@ -47,34 +81,54 @@ export const create = (context) => ({
       },
     });
   },
-  [`MemberExpression[property.name='textContent'][parent.callee.name='expect'][parent.parent.property.name=/toBe$|to(Strict)?Equal/]`](
+  [`MemberExpression[property.name='textContent'][parent.callee.name='expect'][parent.parent.property.name=/^(toBe|toEqual|toStrictEqual)$/]`](
     node,
   ) {
+    const expectedArg = node.parent.parent.parent.arguments[0];
     context.report({
       node: node.parent,
       message: `Use toHaveTextContent instead of asserting on DOM node attributes`,
-      fix: (fixer) => [
-        fixer.removeRange([node.object.range[1], node.property.range[1]]),
-        fixer.replaceTextRange(
-          node.parent.parent.property.range,
-          "toHaveTextContent",
-        ),
-      ],
+      fix: (fixer) => {
+        const replacementPattern = getExactReplacementPattern(expectedArg);
+
+        if (replacementPattern === null) {
+          return null;
+        }
+
+        return [
+          fixer.removeRange([node.object.range[1], node.property.range[1]]),
+          fixer.replaceTextRange(
+            node.parent.parent.property.range,
+            "toHaveTextContent",
+          ),
+          fixer.replaceTextRange(expectedArg.range, replacementPattern),
+        ];
+      },
     });
   },
-  [`MemberExpression[property.name='textContent'][parent.callee.name='expect'][parent.parent.property.name='not'][parent.parent.parent.property.name=/toBe$|to(Strict)?Equal/]`](
+  [`MemberExpression[property.name='textContent'][parent.callee.name='expect'][parent.parent.property.name='not'][parent.parent.parent.property.name=/^(toBe|toEqual|toStrictEqual)$/]`](
     node,
   ) {
+    const expectedArg = node.parent.parent.parent.parent.arguments[0];
     context.report({
       node: node.parent,
       message: `Use toHaveTextContent instead of asserting on DOM node attributes`,
-      fix: (fixer) => [
-        fixer.removeRange([node.object.range[1], node.property.range[1]]),
-        fixer.replaceTextRange(
-          node.parent.parent.parent.property.range,
-          "toHaveTextContent",
-        ),
-      ],
+      fix: (fixer) => {
+        const replacementPattern = getExactReplacementPattern(expectedArg);
+
+        if (replacementPattern === null) {
+          return null;
+        }
+
+        return [
+          fixer.removeRange([node.object.range[1], node.property.range[1]]),
+          fixer.replaceTextRange(
+            node.parent.parent.parent.property.range,
+            "toHaveTextContent",
+          ),
+          fixer.replaceTextRange(expectedArg.range, replacementPattern),
+        ];
+      },
     });
   },
   [`MemberExpression[property.name='textContent'][parent.callee.name='expect'][parent.parent.property.name='not'][parent.parent.parent.property.name=/toContain$|toMatch$/]`](

--- a/src/rules/prefer-to-have-text-content.js
+++ b/src/rules/prefer-to-have-text-content.js
@@ -4,41 +4,6 @@
  */
 import { getSourceCode } from "../context";
 
-const escapeForRegexLiteral = (value) =>
-  value
-    .toString()
-    .replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&")
-    .replace(/\//g, "\\/")
-    .replace(/\n/g, "\\n")
-    .replace(/\r/g, "\\r")
-    .replace(/\u2028/g, "\\u2028")
-    .replace(/\u2029/g, "\\u2029");
-const getExactReplacementPattern = (expectedArg) => {
-  if (!expectedArg) {
-    return null;
-  }
-
-  if (expectedArg.type === "Literal" && typeof expectedArg.value === "string") {
-    return `/^${escapeForRegexLiteral(expectedArg.value)}$/`;
-  }
-
-  if (
-    expectedArg.type === "TemplateLiteral" &&
-    expectedArg.expressions.length === 0
-  ) {
-    const cookedValue = expectedArg.quasis[0].value.cooked;
-
-    /* istanbul ignore next -- Espree rejects malformed untagged templates. */
-    if (cookedValue === null) {
-      return null;
-    }
-
-    return `/^${escapeForRegexLiteral(cookedValue)}$/`;
-  }
-
-  return null;
-};
-
 export const meta = {
   docs: {
     category: "Best Practices",
@@ -85,51 +50,17 @@ export const create = (context) => ({
   [`MemberExpression[property.name='textContent'][parent.callee.name='expect'][parent.parent.property.name=/^(toBe|toEqual|toStrictEqual)$/]`](
     node,
   ) {
-    const expectedArg = node.parent.parent.parent.arguments[0];
     context.report({
       node: node.parent,
       message: `Use toHaveTextContent instead of asserting on DOM node attributes`,
-      fix: (fixer) => {
-        const replacementPattern = getExactReplacementPattern(expectedArg);
-
-        if (replacementPattern === null) {
-          return null;
-        }
-
-        return [
-          fixer.removeRange([node.object.range[1], node.property.range[1]]),
-          fixer.replaceTextRange(
-            node.parent.parent.property.range,
-            "toHaveTextContent",
-          ),
-          fixer.replaceTextRange(expectedArg.range, replacementPattern),
-        ];
-      },
     });
   },
   [`MemberExpression[property.name='textContent'][parent.callee.name='expect'][parent.parent.property.name='not'][parent.parent.parent.property.name=/^(toBe|toEqual|toStrictEqual)$/]`](
     node,
   ) {
-    const expectedArg = node.parent.parent.parent.parent.arguments[0];
     context.report({
       node: node.parent,
       message: `Use toHaveTextContent instead of asserting on DOM node attributes`,
-      fix: (fixer) => {
-        const replacementPattern = getExactReplacementPattern(expectedArg);
-
-        if (replacementPattern === null) {
-          return null;
-        }
-
-        return [
-          fixer.removeRange([node.object.range[1], node.property.range[1]]),
-          fixer.replaceTextRange(
-            node.parent.parent.parent.property.range,
-            "toHaveTextContent",
-          ),
-          fixer.replaceTextRange(expectedArg.range, replacementPattern),
-        ];
-      },
     });
   },
   [`MemberExpression[property.name='textContent'][parent.callee.name='expect'][parent.parent.property.name='not'][parent.parent.parent.property.name=/toContain$|toMatch$/]`](

--- a/src/rules/prefer-to-have-text-content.js
+++ b/src/rules/prefer-to-have-text-content.js
@@ -27,6 +27,12 @@ const getExactReplacementPattern = (expectedArg) => {
     expectedArg.expressions.length === 0
   ) {
     const cookedValue = expectedArg.quasis[0].value.cooked;
+
+    /* istanbul ignore next -- Espree rejects malformed untagged templates. */
+    if (cookedValue === null) {
+      return null;
+    }
+
     return `/^${escapeForRegexLiteral(cookedValue)}$/`;
   }
 

--- a/src/rules/prefer-to-have-text-content.js
+++ b/src/rules/prefer-to-have-text-content.js
@@ -27,11 +27,6 @@ const getExactReplacementPattern = (expectedArg) => {
     expectedArg.expressions.length === 0
   ) {
     const cookedValue = expectedArg.quasis[0].value.cooked;
-
-    if (cookedValue === null) {
-      return null;
-    }
-
     return `/^${escapeForRegexLiteral(cookedValue)}$/`;
   }
 


### PR DESCRIPTION
**What**: Preserve exact text assertion semantics by reporting `textContent` equality checks without autofixing them.

**Why**: `toHaveTextContent` normalizes whitespace before matching, so even an anchored regular expression can weaken `toBe`, `toEqual`, or `toStrictEqual` assertions.

**How**: Equality matchers continue to report but no longer provide a fixer. The existing `toContain` and `toMatch` conversions remain unchanged, and matcher-name matching stays limited to the exact supported names.

**Checklist**:

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged

Closes #337

## Validation

- Prettier check passed
- ESLint passed
- Documentation regeneration check passed
- Full build, tests, and coverage matrix passed across the supported ESLint, Node.js, Testing Library DOM, TypeScript, and parser combinations

AI assistance: OpenAI Codex was used to inspect the issue, implement the focused patch, and review the diff. The final patch and publication were reviewed and controlled by the author.