### PR TITLE
fix(prefer-class): don’t match jest-extended toBeTrue

### DIFF
--- a/src/__tests__/lib/rules/prefer-prefer-to-have-class.js
+++ b/src/__tests__/lib/rules/prefer-prefer-to-have-class.js
@@ -6,6 +6,8 @@ const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 ruleTester.run("prefer-to-have-class", rule, {
   valid: [
     `expect().toBe(true)`,
+    `const el = screen.getByText("foo"); expect(el.classList.contains("bar")).toBeTrue()`,
+    `const el = screen.getByText("foo"); expect(el.classList.contains("bar")).toBeFalse()`,
     `const el = screen.getByText("foo"); expect(el).toHaveClass("bar")`,
     `const el = screen.getByText("foo"); expect(el.class).toEqual(foo)`,
     `const el = screen.getByText("foo"); expect(el).toHaveAttribute("class")`,

--- a/src/rules/prefer-to-have-class.js
+++ b/src/rules/prefer-to-have-class.js
@@ -26,7 +26,7 @@ export const meta = {
 
 export const create = (context) => ({
   //expect(el.classList.contains("foo")).toBe(true)
-  [`CallExpression[callee.object.callee.name=expect][callee.object.arguments.0.callee.object.property.name=classList][callee.object.arguments.0.callee.property.name=contains][callee.property.name=/toBe(Truthy|Falsy)?|to(Strict)?Equal/]`](
+  [`CallExpression[callee.object.callee.name=expect][callee.object.arguments.0.callee.object.property.name=classList][callee.object.arguments.0.callee.property.name=contains][callee.property.name=/^(?:toBe(?:Truthy|Falsy)?|to(?:Strict)?Equal)$/]`](
     node,
   ) {
     const classValue = node.callee.object.arguments[0].arguments[0];


### PR DESCRIPTION
## Checks

- [x] I have read the contributing guidelines.

## Changes

- Anchor the `prefer-to-have-class` matcher selector to the exact supported matcher names.
- Add valid regression cases for jest-extended `toBeTrue()` and `toBeFalse()`.

## Context

Fixes #380

Validation: 63 targeted Jest tests pass; changed-file ESLint and Prettier checks pass; `git diff --check` passes.

AI assistance: OpenAI Codex assisted with the implementation and validation; the contributor reviewed the final diff and test results.