### PR TITLE
chore: don't explicitly manage typescript

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -114,6 +114,10 @@ jobs:
       - name: Install @testing-library/dom v${{ matrix.testing-library-dom }}
         run: npm install --force @testing-library/dom@${{ matrix.testing-library-dom }}
 
+        # these versions of Node use npm v6, which does not install peer dependencies
+      - if: ${{ matrix.node == '12.x' || matrix.node == '14.x' }}
+        run: npm install --force typescript@4
+
       - if: ${{ matrix.eslint >= 9 }}
         run: npm install --force @typescript-eslint/parser
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -114,10 +114,6 @@ jobs:
       - name: Install @testing-library/dom v${{ matrix.testing-library-dom }}
         run: npm install --force @testing-library/dom@${{ matrix.testing-library-dom }}
 
-      - name: Install TypeScript v4
-        if: ${{ matrix.node == '12.x' }}
-        run: npm install --force typescript@4
-
       - if: ${{ matrix.eslint >= 9 }}
         run: npm install --force @typescript-eslint/parser
 

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "jest": "^28.1.3",
     "jest-snapshot-serializer-raw": "^1.2.0",
     "prettier": "^3.9.6",
-    "semver": "^7.6.0",
-    "typescript": "^5.1.3"
+    "semver": "^7.6.0"
   },
   "peerDependencies": {
     "@testing-library/dom": "^8.0.0 || ^9.0.0 || ^10.0.0",


### PR DESCRIPTION
We're not using it directly, and npm v7+ should install it automatically as it's a peer dependency