### PR TITLE
fix: keep the closing paren when removing a property access

### DIFF
--- a/src/__tests__/__fixtures__/createBannedAttributeTestCases.js
+++ b/src/__tests__/__fixtures__/createBannedAttributeTestCases.js
@@ -90,6 +90,17 @@ export default ({ preferred, negatedPreferred, mixedPreferred, attribute }) => {
           ],
           output: `const el = getByRole('button'); expect(el).${preferred}`,
         },
+        // A parenthesized element expression. Parentheses are not AST nodes, so
+        // the object's range ends before the `)` and removing from there eats it.
+        {
+          code: `const el = getByRole('button'); expect((el).${attribute}).toBe(true)`,
+          errors: [
+            {
+              message: `Use ${preferred} instead of checking .${attribute} directly`,
+            },
+          ],
+          output: `const el = getByRole('button'); expect((el)).${preferred}`,
+        },
       ];
 
   // covers partial matchers for aria-<attribute>=mixed

--- a/src/__tests__/lib/rules/prefer-to-have-text-content.test.js
+++ b/src/__tests__/lib/rules/prefer-to-have-text-content.test.js
@@ -35,6 +35,18 @@ ruleTester.run("prefer-to-have-text-content", rule, {
       ],
       output: `expect(element).toHaveTextContent("foo")`,
     },
+    // A parenthesized element expression. Parentheses are not AST nodes, so the
+    // object's range ends before the `)` and removing from there eats it.
+    {
+      code: 'expect((element).textContent).toBe("foo")',
+      errors: [
+        {
+          message:
+            "Use toHaveTextContent instead of asserting on DOM node attributes",
+        },
+      ],
+      output: `expect((element)).toHaveTextContent("foo")`,
+    },
     {
       code: 'expect(element.textContent).not.toBe("foo")',
       errors: [

--- a/src/context.js
+++ b/src/context.js
@@ -7,6 +7,26 @@ export function getSourceCode(context) {
   return context.getSourceCode();
 }
 
+/**
+ * The range covering `.property`, starting at the dot rather than at the end of
+ * the object. Parentheses are not AST nodes, so for `(el).disabled` the object's
+ * range ends before the `)`, and a removal starting there takes the `)` with it
+ * and leaves unparseable output.
+ *
+ * @param context
+ * @param property the MemberExpression's property node
+ *
+ * @return {[number, number]}
+ */
+export function propertyAccessRange(context, property) {
+  const dot = getSourceCode(context).getTokenBefore(
+    property,
+    (token) => token.value === ".",
+  );
+
+  return [dot.range[0], property.range[1]];
+}
+
 /* istanbul ignore next */
 export function getScope(context, node) {
   const sourceCode = getSourceCode(context);

--- a/src/createBannedAttributeRule.js
+++ b/src/createBannedAttributeRule.js
@@ -1,4 +1,5 @@
 import { getQueryNodeFrom } from "./assignment-ast";
+import { propertyAccessRange } from "./context";
 
 export default ({ preferred, negatedPreferred, mixedPreferred, attributes }) =>
   (context) => {
@@ -79,7 +80,7 @@ export default ({ preferred, negatedPreferred, mixedPreferred, attributes }) =>
         }
 
         const {
-          arguments: [{ object, property, property: { name } = {} }],
+          arguments: [{ property, property: { name } = {} }],
         } = node.callee.object;
         const matcher = node.callee.property.name;
         const matcherArg = node.arguments.length && node.arguments[0].value;
@@ -105,7 +106,7 @@ export default ({ preferred, negatedPreferred, mixedPreferred, attributes }) =>
           node,
           message: `Use ${correctFunction}() instead of checking .${name} directly`,
           fix: (fixer) => [
-            fixer.removeRange([object.range[1], property.range[1]]),
+            fixer.removeRange(propertyAccessRange(context, property)),
             fixer.replaceTextRange(
               [node.callee.property.range[0], node.range[1]],
               `${correctFunction}()`,

--- a/src/rules/prefer-to-have-text-content.js
+++ b/src/rules/prefer-to-have-text-content.js
@@ -2,7 +2,7 @@
  * @fileoverview prefer toHaveAttribute over checking  getAttribute/hasAttribute
  * @author Ben Monro
  */
-import { getSourceCode } from "../context";
+import { getSourceCode, propertyAccessRange } from "../context";
 
 export const meta = {
   docs: {
@@ -26,7 +26,7 @@ export const create = (context) => ({
       message: `Use toHaveTextContent instead of asserting on DOM node attributes`,
       fix: (fixer) => {
         return [
-          fixer.removeRange([node.object.range[1], node.property.range[1]]),
+          fixer.removeRange(propertyAccessRange(context, node.property)),
           fixer.replaceTextRange(
             node.parent.parent.property.range,
             "toHaveTextContent",
@@ -54,7 +54,7 @@ export const create = (context) => ({
       node: node.parent,
       message: `Use toHaveTextContent instead of asserting on DOM node attributes`,
       fix: (fixer) => [
-        fixer.removeRange([node.object.range[1], node.property.range[1]]),
+        fixer.removeRange(propertyAccessRange(context, node.property)),
         fixer.replaceTextRange(
           node.parent.parent.property.range,
           "toHaveTextContent",
@@ -69,7 +69,7 @@ export const create = (context) => ({
       node: node.parent,
       message: `Use toHaveTextContent instead of asserting on DOM node attributes`,
       fix: (fixer) => [
-        fixer.removeRange([node.object.range[1], node.property.range[1]]),
+        fixer.removeRange(propertyAccessRange(context, node.property)),
         fixer.replaceTextRange(
           node.parent.parent.parent.property.range,
           "toHaveTextContent",
@@ -86,7 +86,7 @@ export const create = (context) => ({
       node: node.parent,
       message: `Use toHaveTextContent instead of asserting on DOM node attributes`,
       fix: (fixer) => [
-        fixer.removeRange([node.object.range[1], node.property.range[1]]),
+        fixer.removeRange(propertyAccessRange(context, node.property)),
         fixer.replaceTextRange(
           node.parent.parent.parent.property.range,
           "toHaveTextContent",


### PR DESCRIPTION
## Problem

When the element expression is parenthesized, the autofix removes the closing paren and produces code that
does not parse:

```js
const el = getByRole("button");
expect((el).disabled).toBe(true);
```

`eslint --fix` →

```js
const el = getByRole("button");
expect((el).toBeDisabled();
```

```
error  Parsing error: Unexpected token ;
```

The fixer removes `[object.range[1], property.range[1]]`. Parentheses are not AST nodes, so for
`(el).disabled` the object's range ends before the `)` and the removal takes it too.

Affects `prefer-enabled-disabled`, `prefer-required`, `prefer-checked` and `prefer-pressed` through the
shared `createBannedAttributeRule`, plus all four handlers in `prefer-to-have-text-content`. Plain
JavaScript, default parser — no TypeScript involved, though a cast is a common way to end up with the
parens, since `(el as HTMLButtonElement).disabled` requires them.

## Solution

Anchor the removal on the `.` token instead of the end of the object, so exactly the property access is
removed however the object is written. The element expression is preserved as authored, matching the
surrounding fixes. The helper lives in `src/context.js` beside `getSourceCode`, which both call sites
already use.

## Commit structure

Two commits, so the failure can be reproduced before the fix:

- **`3e0e1ed` — `test:` adds the failing cases only.** Check this commit out and run `npm test` to see the
  bug: `RuleTester` reports *"A fatal parsing error occurred in autofix"* for four cases. **CI is expected
  to be red at this commit** — that is the point of it, not an oversight.
- **`bd7f858` — `fix:` the five sites.** 622/622 tests pass, lint clean, coverage stays at 100%.

Happy to squash if you prefer a single commit on `main`.

## Note

Prepared with AI assistance. The diagnosis, the fix and the tests were verified locally against ESLint
9.39.5 with both the default parser and `@typescript-eslint/parser`; a human reviewed and is submitting it.
